### PR TITLE
Update README install command to work with Linux as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For installation options check [Installation](https://github.com/babashka/babash
 For quick installation use:
 
 ``` shell
-$ bash <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+$ bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
 ```
 
 or grab a binary from [Github


### PR DESCRIPTION
Hi,

Just updating the basic install command to work with Linux and OSX. Please, if you agree and want to merge this micro improvements, go ahead. 

Why this change:

At Linux (Ubuntu) when I trying to install with `bash <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)` I get: bash: /dev/fd/63: No such file or directory

` <(...)` operator is also known as process substitution and is a way to run command, the output of which goes into the anonymous pipe, in this case: /dev/fd/63. More context can be [found](https://askubuntu.com/questions/678915/whats-the-difference-between-and-in-bash/678919#678919). But maybe is just some issue on my Linux machine, works as it is on Mac.


Thanks 