### PR TITLE
Don't leave the user stranded in install_dir

### DIFF
--- a/install
+++ b/install
@@ -66,6 +66,7 @@ esac
 
 download_url="https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-amd64.zip"
 
+(
 mkdir -p "$download_dir"
 cd "$download_dir"
 echo -e "Downloading $download_url to $download_dir"
@@ -86,3 +87,4 @@ then
 fi
 
 echo "Successfully installed bb in $install_dir"
+)


### PR DESCRIPTION
After the installation completes, the user would be CDed into `$install_dir` regardless of where they started from - this is bad practice.

Its better to run actual operations (i.e. other than parsing input and setting local variables) in a subshell, so when it exists - the user is back to where they started. shell options and exit codes will be translated automatically across the subshell