### PR TITLE
Update install to support future tar.gz releases

### DIFF
--- a/.circleci/script/docker
+++ b/.circleci/script/docker
@@ -17,12 +17,12 @@ fi
 if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
     echo "Building Docker image $image_name:$image_tag"
     echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
-    unzip "/tmp/release/babashka-${image_tag}-linux-amd64.zip"
+    tar zxvf  "/tmp/release/babashka-${image_tag}-linux-amd64.tar.gz"
     docker build -t "$image_name" -f Dockerfile.ci .
     docker tag "$image_name:$latest_tag" "$image_name:$image_tag"
     rm -f bb
     if [[ $snapshot == "false" ]]; then
-        unzip "/tmp/release/babashka-${image_tag}-linux-static-amd64.zip"
+        tar zxvf  "/tmp/release/babashka-${image_tag}-linux-static-amd64.tar.gz"
         docker build -t "$image_name:alpine" -f Dockerfile.alpine .
         docker tag "$image_name:alpine" "$image_name:$image_tag-alpine"
     fi

--- a/.circleci/script/publish_artifact.clj
+++ b/.circleci/script/publish_artifact.clj
@@ -16,7 +16,7 @@
       (curl/post slack-hook-url {:headers {"content-type" "application/json"}
                                  :body json}))))
 
-(def release-text (format "[%s - %s@%s]: https://%s-201467090-gh.circle-artifacts.com/0/release/babashka-%s-%s-amd64.zip"
+(def release-text (format "[%s - %s@%s]: https://%s-201467090-gh.circle-artifacts.com/0/release/babashka-%s-%s-amd64.tar.gz"
                           (System/getenv "BABASHKA_PLATFORM")
                           (System/getenv "CIRCLE_BRANCH")
                           (System/getenv "CIRCLE_SHA1")

--- a/.circleci/script/release
+++ b/.circleci/script/release
@@ -11,9 +11,9 @@ cd /tmp/release
 mkdir -p /tmp/bb_size
 ./bb '(spit "/tmp/bb_size/size" (.length (io/file "bb")))'
 
-## release binary as zip archive
+## release binary as tar.gz archive
 
-zip "babashka-$VERSION-$BABASHKA_PLATFORM-amd64.zip" bb # bbk
+tar zcvf "babashka-$VERSION-$BABASHKA_PLATFORM-amd64.tar.gz" bb # bbk
 
 ## cleanup
 

--- a/install
+++ b/install
@@ -64,25 +64,36 @@ case "$(uname -s)" in
     Darwin*)    platform=macos;;
 esac
 
+# Ugly ugly conversion of version to a comparable number
+IFS='.' read -ra VER <<< "$version"
+vernum=$(printf "%03d%03d%03d" "${VER[0]}" "${VER[1]}" "${VER[2]}")
+
+if [[ $vernum -le 000002013 ]]; then
+  ext="zip"
+  util="$(which unzip) -qqo"
+else
+  ext="tar.gz"
+  util="$(which tar) -zxf"
+fi
+
 download_url="https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-amd64.zip"
 
 mkdir -p "$download_dir"
 cd "$download_dir"
 echo -e "Downloading $download_url to $download_dir"
-rm -rf "babashka-$version-$platform-amd64.zip"
+rm -rf "babashka-$version-$platform-amd64."$ext
 rm -rf "bb"
-curl -o "babashka-$version-$platform-amd64.zip" -sL "https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-amd64.zip"
-unzip -qqo "babashka-$version-$platform-amd64.zip"
-rm "babashka-$version-$platform-amd64.zip"
+curl -o "babashka-$version-$platform-amd64."$ext -sL "https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-amd64."$ext
+$util "babashka-$version-$platform-amd64."$ext
+rm "babashka-$version-$platform-amd64."$ext
 
 if [ "$download_dir" != "$install_dir" ]
 then
     mkdir -p "$install_dir"
-    cd "$install_dir"
-    if [ -f bb ]; then
+    if [ -f "$install_dir/bb" ]; then
         echo "Moving $install_dir/bb to $install_dir/bb.old"
     fi
-    mv -f "$download_dir/bb" "$PWD/bb"
+    mv -f "$download_dir/bb" "$install_dir/bb"
 fi
 
 echo "Successfully installed bb in $install_dir"


### PR DESCRIPTION
This PR will allow future releases to be packaged at .tar.gz. This is probably better since many docker containers don't come with `unzip`, but do come with `tar`.

We use a crappy version check (thank you, bash) to see if the version we are downloading is newer than the current (0.2.13), and if so, then use `tar` and a _.tar.gz_ extension.

Make sure to not merge this unless 0.2.14 is ready to be released in tar format!

- [ ] Convert CI settings to release tagged releases as tar.gz.