### PR TITLE
install: Use $download_url

### DIFF
--- a/install
+++ b/install
@@ -81,14 +81,14 @@ else
   util="$(which tar) -zxf"
 fi
 
-download_url="https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-$arch.zip"
+download_url="https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-$arch."$ext
 
 mkdir -p "$download_dir"
 cd "$download_dir"
 echo -e "Downloading $download_url to $download_dir"
 rm -rf "babashka-$version-$platform-$arch."$ext
 rm -rf "bb"
-curl -o "babashka-$version-$platform-$arch."$ext -sL "https://github.com/babashka/babashka/releases/download/v$version/babashka-$version-$platform-$arch."$ext
+curl -o "babashka-$version-$platform-$arch."$ext -sL $download_url
 $util "babashka-$version-$platform-$arch."$ext
 rm "babashka-$version-$platform-$arch."$ext
 


### PR DESCRIPTION
We were only using this var in the echo, but it always said .zip, even
if we were using .tar.gz