### PR TITLE
Fix cookie-parsing bug in the example note-taking app

### DIFF
--- a/examples/notes.clj
+++ b/examples/notes.clj
@@ -88,7 +88,7 @@
 
 (defn get-session-id [headers]
   (if-let [cookie-header (first (filter #(str/starts-with? % "Cookie: ") headers))]
-    (let [parts (str/split cookie-header #"; ")]
+    (let [parts (str/split (str/replace cookie-header "Cookie: " "") #"; ")]
       (if-let [notes-id (first (filter #(str/starts-with? % "notes-id") parts))]
         (str/replace notes-id "notes-id=" "")
         (new-session!)))


### PR DESCRIPTION
I'm also working on rewriting this to use org.httpkit.server as suggested in the comment at the top of the file. But until then, here's a bug fix for the hand-rolled server.