### PR TITLE
Use get-classpath when build an uberjar

### DIFF
--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -729,7 +729,7 @@ When no eval opts or subcommand is provided, the implicit subcommand is repl.")
         (when uberjar
           (uberjar/run {:dest uberjar
                         :jar :uber
-                        :classpath classpath
+                        :classpath (cp/get-classpath)
                         :main-class main
                         :verbose verbose?}))
         exit-code))))

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -1,6 +1,5 @@
 (ns babashka.bb-edn-test
   (:require
-   [babashka.fs :as fs]
    [babashka.test-utils :as test-utils]
    [clojure.edn :as edn]
    [clojure.string :as str]
@@ -12,16 +11,8 @@
     :eof nil}
    (apply test-utils/bb nil (map str args))))
 
-(defmacro with-config [cfg & body]
-  `(let [temp-dir# (fs/create-temp-dir)
-         bb-edn-file# (fs/file temp-dir# "bb.edn")]
-     (binding [*print-meta* true]
-       (spit bb-edn-file# ~cfg))
-     (binding [test-utils/*bb-edn-path* (str bb-edn-file#)]
-       ~@body)))
-
 (deftest doc-test
-  (with-config {:paths ["test-resources/task_scripts"]}
+  (test-utils/with-config {:paths ["test-resources/task_scripts"]}
     (is (str/includes? (apply test-utils/bb nil
                               (map str ["doc" "tasks"]))
                        "This is task ns docstring."))
@@ -33,11 +24,11 @@
                        "Main docstring"))))
 
 (deftest deps-test
-  (with-config '{:deps {medley/medley {:mvn/version "1.3.0"}}}
+  (test-utils/with-config '{:deps {medley/medley {:mvn/version "1.3.0"}}}
     (is (= '{1 {:id 1}, 2 {:id 2}}
            (bb "-e" "(require 'medley.core)" "-e" "(medley.core/index-by :id [{:id 1} {:id 2}])"))))
   (testing "--classpath option overrides bb.edn"
-    (with-config '{:deps {medley/medley {:mvn/version "1.3.0"}}}
+    (test-utils/with-config '{:deps {medley/medley {:mvn/version "1.3.0"}}}
       (is (= "src"
              (bb "-cp" "src" "-e" "(babashka.classpath/get-classpath)"))))))
 
@@ -46,6 +37,6 @@
 ;; Or do we want `--aliases :foo:bar`
 ;; Let's wait for a good use case
 #_(deftest alias-deps-test
-  (with-config '{:aliases {:medley {:deps {medley/medley {:mvn/version "1.3.0"}}}}}
+  (test-utils/with-config '{:aliases {:medley {:deps {medley/medley {:mvn/version "1.3.0"}}}}}
     (is (= '{1 {:id 1}, 2 {:id 2}}
            (bb "-A:medley" "-e" "(require 'medley.core)" "-e" "(medley.core/index-by :id [{:id 1} {:id 2}])")))))

--- a/test/babashka/test_utils.clj
+++ b/test/babashka/test_utils.clj
@@ -1,5 +1,6 @@
 (ns babashka.test-utils
   (:require
+   [babashka.fs :as fs]
    [babashka.impl.classpath :as cp]
    [babashka.main :as main]
    [babashka.process :as p]
@@ -106,3 +107,11 @@
 
 (defn stop-server! [^java.net.ServerSocket server]
   (.close server))
+
+(defmacro with-config [cfg & body]
+  `(let [temp-dir# (fs/create-temp-dir)
+         bb-edn-file# (fs/file temp-dir# "bb.edn")]
+     (binding [*print-meta* true]
+       (spit bb-edn-file# ~cfg))
+     (binding [*bb-edn-path* (str bb-edn-file#)]
+       ~@body)))

--- a/test/babashka/uberjar_test.clj
+++ b/test/babashka/uberjar_test.clj
@@ -5,10 +5,10 @@
    [clojure.test :as t :refer [deftest is testing]]))
 
 (deftest uberjar-test
-  (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
-        path (.getPath tmp-file)]
-    (.deleteOnExit tmp-file)
-    (testing "uberjar"
+  (testing "uberjar with --main"
+    (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
+          path (.getPath tmp-file)]
+      (.deleteOnExit tmp-file)
       (tu/bb nil "uberjar" path "--classpath" "test-resources/babashka/uberjar/src" "-m" "my.main-main")
       (is (= "(\"1\" \"2\" \"3\" \"4\")\n"
              (tu/bb nil "--jar" path "1" "2" "3" "4")))
@@ -25,4 +25,15 @@
           path (.getPath tmp-file)]
       (.deleteOnExit tmp-file)
       (tu/bb nil "uberjar" path "--classpath" "test-resources/babashka/uberjar/src")
-      (is (str/includes? (tu/bb "(+ 1 2 3)" path) "6")))))
+      (is (str/includes? (tu/bb "(+ 1 2 3)" path) "6"))))
+  (testing "use bb.edn classpath when no other --classpath"
+    (tu/with-config {:paths ["test-resources/babashka/uberjar/src"]}
+      (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
+            path (.getPath tmp-file)]
+        (.deleteOnExit tmp-file)
+        ;; building with no --classpath
+        (tu/bb nil "uberjar" path "-m" "my.main-main")
+        ;; running
+        (is (= "(\"42\")\n" (tu/bb nil "--jar" path "-m" "my.main-main" "42")))
+        (is (= "(\"42\")\n" (tu/bb nil "--classpath" path "-m" "my.main-main" "42")))
+        (is (= "(\"42\")\n" (tu/bb nil path "42")))))))


### PR DESCRIPTION
It was previously using the classpath coming from the parameters/env. We need to use
cp/get-classpath for taking into consideration the classpath coming from bb.edn.