### PR TITLE
Add class `java.util.zip.ZipOutputStream`

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -256,6 +256,7 @@
           java.util.zip.GZIPInputStream
           java.util.zip.GZIPOutputStream
           java.util.zip.ZipInputStream
+          java.util.zip.ZipOutputStream
           java.util.zip.ZipEntry
           ~(symbol "[B")
           ~(symbol "[I")


### PR DESCRIPTION
This will enable the creation of zip files via babashka scripts.  
To quote your reply on Slack:
> We already have `GZIPOutputStream` so it's a bit silly that we don't have `ZIP`

😃