### PR TITLE
Add sha256sum check to zlib

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -84,6 +84,7 @@ if [ "$BABASHKA_STATIC" = "true" ]; then
     ZLIB_VERSION="1.2.11"
 
     curl -O -sL "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
+    echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1 zlib-${ZLIB_VERSION}.tar.gz" | sha256sum --check
     tar xf "zlib-${ZLIB_VERSION}.tar.gz"
     cd "zlib-${ZLIB_VERSION}"
     CC=musl-gcc ./configure --static --prefix=/usr/lib/x86_64-linux-musl/


### PR DESCRIPTION
Just to make sure that we are using the correct source code.

The SHA256 can be double checked in the https://zlib.net/ website.