### PR TITLE
Improve `clojure.java.browse`

### DIFF
--- a/src/babashka/impl/clojure/java/browse.clj
+++ b/src/babashka/impl/clojure/java/browse.clj
@@ -1,7 +1,10 @@
 (ns babashka.impl.clojure.java.browse
   {:no-doc true}
   (:require [clojure.java.shell :refer [sh]]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [sci.core :as sci]))
+
+(def open-url-script (sci/new-dynamic-var '*open-url-script* (atom nil)))
 
 (def os
   (let [os-name (System/getProperty "os.name")
@@ -15,11 +18,13 @@
 
 (defn browse-url [url]
   (let [url (str url)]
-    (case os
-      :mac (sh "/usr/bin/open" url)
-      :linux (sh "xdg-open" url)
-      :windows (sh "cmd" "/C" "start" url))))
+    (if-let [script (-> open-url-script deref deref)]
+      (sh script url)
+      (case os
+        :mac (sh "/usr/bin/open" url)
+        :linux (sh "xdg-open" url)
+        :windows (sh "cmd" "/C" "start" url)))))
 
 (def browse-namespace
-  {'browse-url browse-url})
-
+  {'*open-url-script* open-url-script
+   'browse-url        browse-url})

--- a/src/babashka/impl/clojure/java/browse.clj
+++ b/src/babashka/impl/clojure/java/browse.clj
@@ -17,7 +17,7 @@
   (let [url (str url)]
     (case os
       :mac (sh "/usr/bin/open" url)
-      :linux (sh "/usr/bin/xdg-open" url)
+      :linux (sh "xdg-open" url)
       :windows (sh "cmd" "/C" "start" url))))
 
 (def browse-namespace


### PR DESCRIPTION
# Context

This PR add two improvements to `babashka.impl.clojure.java.browse`, fixing issue https://github.com/babashka/babashka/issues/845.

## Remove `xdg-open` hardcoded path in `babashka.impl.clojure.java.browse`

Binaries in Linux are not guarantee to be located on `/usr/bin`.

For example, NixOS the binaries are located in `/run/current-system/sw/bin/xdg-open` (that is actually just a symlink to `/nix/store`). The distro may also not have `xdg-open` installed at `/`, instead the user may put it somewhere else like `$HOME/bin`.

This commit fixes this by using not hardcoding the PATH of `xdg-open`, instead relying on shell path to search it.

## Implement `clojure.java.browse/*open-url-script*`

This allows usage of a custom URL script, like:

```clojure
(binding [*open-url-script* (atom "my-browse-url-script")]
  (browse-url "https://google.com"))
```

`*open-url-script*` is an atom just to keep compatibility with Clojure.

Described here: <https://clojuredocs.org/clojure.java.browse/*open-url-script*>
