### PR TITLE
Improve script/setup-musl

### DIFF
--- a/script/setup-musl
+++ b/script/setup-musl
@@ -47,16 +47,10 @@ arch=${BABASHKA_ARCH:-"x86_64"}
 echo "ARCH: $arch"
 
 cd "zlib-${ZLIB_VERSION}"
-CC=musl-gcc ./configure --static --prefix=/usr/lib/$arch-linux-musl/
+CC=musl-gcc ./configure --static --prefix="/usr/local"
 make CC=musl-gcc
-sudo make install
-export CC=gcc
+make install
 cd ..
 
-# depending on GCC version, we will have different directories here.
-# for example, for GCC 6.3.0 we will have:
-# - /usr/lib/gcc/x86_64-linux-gnu/6
-# - /usr/lib/gcc/x86_64-linux-gnu/6.3.0
-for dest_dir in /usr/lib/gcc/$arch-linux-gnu/*; do
-    sudo cp -f /usr/lib/$arch-linux-musl/lib/libz.a "$dest_dir"
-done
+# Add a symbolic link pointing libz to the correct place so ldd can find it
+ln -sf "/usr/local/lib/libz.a" "/usr/lib/$arch-linux-musl/libz.a"

--- a/script/setup-musl
+++ b/script/setup-musl
@@ -52,5 +52,5 @@ make CC=musl-gcc
 make install
 cd ..
 
-# Add a symbolic link pointing libz to the correct place so ldd can find it
-ln -sf "/usr/local/lib/libz.a" "/usr/lib/$arch-linux-musl/libz.a"
+# Install libz.a in the correct place so ldd can find it
+install -Dm644 "/usr/local/lib/libz.a" "/usr/lib/$arch-linux-musl/libz.a"


### PR DESCRIPTION
I was trying to understand why we needed that hack to copy `libz.a` to the GCC library path even if GraalVM is supposed to set the linker correctly if we had `musl-gcc` at our PATH.

I finally figured the issue. As you can see in the code below, `zlib` sets `libdir` to the directory passed on `--prefix` and appends `/lib`:

https://github.com/madler/zlib/blob/v1.2.11/configure#L76

This would work fine if `/usr/lib` was the expected location for libraries (however the script was still wrong, since `--prefix` would need to be set to `/usr` for it to work correctly), however on Debian each library has the following format depending on the architecture/compiler:

- `/usr/lib/x86_64-linux-musl`
- `/usr/lib/x86_64-linux-gcc`

So passing `/usr/lib/x86_64-linux-musl` to the `--prefix` parameter on `zlib` results on `libz.a` installed on:

- `/usr/lib/x86_64-linux-musl/lib`

That is clearly wrong. Sadly there is no way to fix this without patching `configure` script on `zlib`, so let's change `--prefix` to
`/usr/local`, that is the correct place for non-distro programs/libraries anyway, and symbolic link `/usr/local/lib/libz.a` to
the correct path (`/usr/lib/x86_64-linux-musl`). This works and it is quite a clean solution.