### PR TITLE
add more windows testing (#235)

### DIFF
--- a/script/test.bat
+++ b/script/test.bat
@@ -8,4 +8,14 @@ echo "BABASHKA_TEST_ENV: %BABASHKA_TEST_ENV%"
 set JAVA_HOME=%GRAALVM_HOME%
 set PATH=%GRAALVM_HOME%\bin;%PATH%
 
+set BABASHKA_PRELOADS=
+set BABASHKA_CLASSPATH=
+set BABASHKA_PRELOADS_TEST=
+
+echo "running tests part 1"
 call lein do clean, test :windows
+
+set BABASHKA_PRELOADS=(defn __bb__foo [] "foo") (defn __bb__bar [] "bar")
+set BABASHKA_PRELOADS_TEST=true
+echo "running tests part 2"
+call lein test :only babashka.main-test/preloads-test

--- a/test/babashka/scripts/System.bb
+++ b/test/babashka/scripts/System.bb
@@ -1,5 +1,5 @@
 [(System/getProperty "user.dir")
  (System/getProperty "foo" "bar")
- (System/getenv "HOME")
+ (or (System/getenv "HOME") (System/getenv "HOMEPATH"))
  (System/getProperties)
  (System/getenv)]

--- a/test/babashka/test_utils.clj
+++ b/test/babashka/test_utils.clj
@@ -19,6 +19,11 @@
     (str/replace s "\r\n" "\n")
     s))
 
+(defn escape-file-paths [s]
+  (if main/windows?
+    (str/replace s "\\" "\\\\")
+    s))
+
 (def ^:dynamic *bb-edn-path* nil)
 
 (defmethod clojure.test/report :begin-test-var [m]
@@ -86,7 +91,7 @@
         exit (:exit res)
         error? (pos? exit)]
     (if error? (throw (ex-info (or (:err res) "") {}))
-        (:out res))))
+               (normalize (:out res)))))
 
 (def bb
   (case (System/getenv "BABASHKA_TEST_ENV")


### PR DESCRIPTION
A handful of tests are failing on my WSL build, but they also fail when running the tests from master, so it seems like there are some kinks to work out in my WSL testing. It doesn't seem related to these changes, but it might not hurt to let the CI checks run first to make sure Linux/Mac are held harmless by these changes (mainly just the normalize call on `bb-native`).

- add `normalize` call to `bb-native` output
- add `escape-file-paths` function to double up backslashes for Windows paths
  passed as strings
- update test.bat to more closely mirror the Linux/Mac test script

The only maybe confusing change IMO is to scripts/System.bb - Windows machines generally use HOMEPATH instead of HOME, so or'ing them should result in non-nil everywhere (as far as I can tell).