### PR TITLE
add more windows testing (#235)

### DIFF
--- a/script/test.bat
+++ b/script/test.bat
@@ -19,3 +19,8 @@ set BABASHKA_PRELOADS=(defn __bb__foo [] "foo") (defn __bb__bar [] "bar")
 set BABASHKA_PRELOADS_TEST=true
 echo "running tests part 2"
 call lein test :only babashka.main-test/preloads-test
+
+set BABASHKA_PRELOADS=(defn ithrow [] (/ 1 0))
+set BABASHKA_PRELOADS_TEST=true
+echo "running tests part 3"
+call lein test :only babashka.main-test/preloads-file-location-test


### PR DESCRIPTION
- just handling line endings and escaping backslashes in file paths

this almost closes the work on porting the `b.main-test` namespace - I think there are only 5-10 tests left, and some of them rely on Unix-y things