### PR TITLE
make tests run on windows as the default (#235)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,6 +65,8 @@ build_script:
 
     bb release-artifact %zip%
 
+    set BABASHKA_EDN=
+
     set BABASHKA_TEST_ENV=native
 
     call script/test.bat

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; :java-source-paths ["sci/reflector/src-java"]
   :java-source-paths ["src-java"]
   :resource-paths ["resources" "sci/resources"]
-  :test-selectors {:windows :windows}
+  :test-selectors {:windows (complement :skip-windows)}
   :dependencies [[org.clojure/clojure "1.11.0-alpha1"]
                  [borkdude/edamame "0.0.11"]
                  [borkdude/graal.locking "0.0.2"]

--- a/script/test.bat
+++ b/script/test.bat
@@ -11,16 +11,32 @@ set PATH=%GRAALVM_HOME%\bin;%PATH%
 set BABASHKA_PRELOADS=
 set BABASHKA_CLASSPATH=
 set BABASHKA_PRELOADS_TEST=
+set BABASHKA_CLASSPATH_TEST=
+set BABASHKA_POD_TEST=
+set BABASHKA_SOCKET_REPL_TEST=
 
 echo "running tests part 1"
-call lein do clean, test :windows
+call lein do clean, test :windows || exit /B 1
 
 set BABASHKA_PRELOADS=(defn __bb__foo [] "foo") (defn __bb__bar [] "bar")
 set BABASHKA_PRELOADS_TEST=true
 echo "running tests part 2"
-call lein test :only babashka.main-test/preloads-test
+call lein test :only babashka.main-test/preloads-test || exit /B 1
 
 set BABASHKA_PRELOADS=(defn ithrow [] (/ 1 0))
 set BABASHKA_PRELOADS_TEST=true
 echo "running tests part 3"
-call lein test :only babashka.main-test/preloads-file-location-test
+call lein test :only babashka.main-test/preloads-file-location-test || exit /B 1
+
+set BABASHKA_PRELOADS=(require '[env-ns])
+set BABASHKA_CLASSPATH_TEST=true
+set BABASHKA_CLASSPATH=test-resources/babashka/src_for_classpath_test/env
+echo "running tests part 4"
+call lein test :only babashka.classpath-test/classpath-env-test || exit /B 1
+
+echo "not running pod tests on windows (yet)"
+REM set BABASHKA_POD_TEST=true
+REM call lein test :only babashka.pod-test || exit /B 1
+
+set BABASHKA_SOCKET_REPL_TEST=true
+call lein test :only babashka.impl.socket-repl-test || exit /B 1

--- a/script/test.bat
+++ b/script/test.bat
@@ -40,3 +40,10 @@ REM call lein test :only babashka.pod-test || exit /B 1
 
 set BABASHKA_SOCKET_REPL_TEST=true
 call lein test :only babashka.impl.socket-repl-test || exit /B 1
+
+set BABASHKA_PRELOADS=
+set BABASHKA_CLASSPATH=
+set BABASHKA_PRELOADS_TEST=
+set BABASHKA_CLASSPATH_TEST=
+set BABASHKA_POD_TEST=
+set BABASHKA_SOCKET_REPL_TEST=

--- a/test/babashka/async_test.clj
+++ b/test/babashka/async_test.clj
@@ -4,7 +4,7 @@
    [clojure.edn :as edn]
    [clojure.test :as t :refer [deftest is]]))
 
-(deftest alts!!-test
+(deftest ^:skip-windows alts!!-test
   (is (= "process 2\n" (test-utils/bb nil "
    (defn async-command [& args]
      (async/thread (apply shell/sh \"bash\" \"-c\" args)))

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -55,16 +55,16 @@
   (testing "map returned from task"
     (test-utils/with-config '{:tasks {foo {:task {:a 1 :b 2}}}}
       (is (= {:a 1 :b 2} (bb "run" "--prn" "foo")))))
-  (let [tmp-dir (fs/create-temp-dir)
-        out     (str (fs/file tmp-dir "out.txt"))
+  (let [tmp-dir  (fs/create-temp-dir)
+        out      (str (fs/file tmp-dir "out.txt"))
         echo-cmd (if main/windows? "cmd /c echo" "echo")
-        ls-cmd (if main/windows? "cmd /c dir" "ls")
-        rn (partial test-utils/normalize)]
+        ls-cmd   (if main/windows? "cmd /c dir" "ls")
+        fix-lines test-utils/normalize]
     (testing "shell test"
       (test-utils/with-config {:tasks {'foo (list 'shell {:out out}
                                               echo-cmd "hello")}}
         (bb "foo")
-        (is (= "hello\n" (rn (slurp out))))))
+        (is (= "hello\n" (fix-lines (slurp out))))))
     (fs/delete out)
     (testing "shell test with :continue fn"
       (test-utils/with-config {:tasks {'foo (list '-> (list 'shell {:out      out
@@ -96,7 +96,7 @@
       (test-utils/with-config {:tasks {'foo (list 'clojure {:out out}
                                               "-M -e" "(println :yolo)")}}
         (bb "foo")
-        (is (= ":yolo\n" (rn (slurp out))))))
+        (is (= ":yolo\n" (fix-lines (slurp out))))))
     (fs/delete out)
     (testing "depends"
       (test-utils/with-config {:tasks {'quux (list 'spit out "quux\n")

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -37,54 +37,66 @@
 (deftest task-test
   (test-utils/with-config '{:tasks {foo (+ 1 2 3)}}
     (is (= 6 (bb "run" "--prn" "foo"))))
+  (testing "init test"
+    (test-utils/with-config '{:tasks {:init (def x 1)
+                                      foo   x}}
+      (is (= 1 (bb "run" "--prn" "foo")))))
+  (testing "requires test"
+    (test-utils/with-config '{:tasks {:requires ([babashka.fs :as fs])
+                                      foo       (fs/exists? ".")}}
+      (is (= true (bb "run" "--prn" "foo"))))
+    (test-utils/with-config '{:tasks {foo {:requires ([babashka.fs :as fs])
+                                           :task     (fs/exists? ".")}}}
+      (is (= true (bb "run" "--prn" "foo"))))
+    (test-utils/with-config '{:tasks {bar {:requires ([babashka.fs :as fs])}
+                                      foo {:depends [bar]
+                                           :task    (fs/exists? ".")}}}
+      (is (= true (bb "run" "--prn" "foo")))))
+  (testing "map returned from task"
+    (test-utils/with-config '{:tasks {foo {:task {:a 1 :b 2}}}}
+      (is (= {:a 1 :b 2} (bb "run" "--prn" "foo")))))
   (let [tmp-dir (fs/create-temp-dir)
-        out     (str (fs/file tmp-dir "out.txt"))]
+        out     (str (fs/file tmp-dir "out.txt"))
+        echo-cmd (if main/windows? "cmd /c echo" "echo")
+        ls-cmd (if main/windows? "cmd /c dir" "ls")
+        rn (partial test-utils/normalize)]
     (testing "shell test"
       (test-utils/with-config {:tasks {'foo (list 'shell {:out out}
-                                                  "echo hello")}}
+                                              echo-cmd "hello")}}
         (bb "foo")
-        (is (= "hello\n" (slurp out)))))
-    (fs/delete out)
-    (testing "shell test with :continue"
-      (test-utils/with-config {:tasks {'foo (list 'shell {:out      out
-                                                          :err      out
-                                                          :continue true}
-                                                  "ls foobar")}}
-        (bb "foo")
-        (is (str/includes? (slurp out)
-                           "foobar"))))
+        (is (= "hello\n" (rn (slurp out))))))
     (fs/delete out)
     (testing "shell test with :continue fn"
       (test-utils/with-config {:tasks {'foo (list '-> (list 'shell {:out      out
                                                                     :err      out
                                                                     :continue '(fn [proc]
                                                                                  (contains? proc :exit))}
-                                                            "ls foobar")
-                                                  :exit)}}
+                                                        ls-cmd "foobar")
+                                              :exit)}}
         (is (pos? (bb "run" "--prn" "foo")))))
     (testing "shell test with :error"
       (test-utils/with-config
         {:tasks {'foo (list '-> (list 'shell {:out      out
                                               :err      out
-                                              :error-fn '(constantly 1337) }
-                                      "ls foobar"))}}
+                                              :error-fn '(constantly 1337)}
+                                  ls-cmd "foobar"))}}
         (is (= 1337 (bb "run" "--prn" "foo"))))
       (test-utils/with-config
-        {:tasks {'foo (list '-> (list 'shell {:out      out
-                                              :err      out
+        {:tasks {'foo (list '-> (list 'shell {:out out
+                                              :err out
                                               :error-fn
-                                              '(fn [opts]
-                                                 (and (:task opts)
-                                                      (:proc opts)
-                                                      (not (zero? (:exit (:proc opts))))))}
-                                      "ls foobar"))}}
+                                                   '(fn [opts]
+                                                      (and (:task opts)
+                                                        (:proc opts)
+                                                        (not (zero? (:exit (:proc opts))))))}
+                                  ls-cmd "foobar"))}}
         (is (true? (bb "run" "--prn" "foo")))))
     (fs/delete out)
     (testing "clojure test"
       (test-utils/with-config {:tasks {'foo (list 'clojure {:out out}
-                                                  "-M -e" "(println :yolo)")}}
+                                              "-M -e" "(println :yolo)")}}
         (bb "foo")
-        (is (= ":yolo\n" (slurp out)))))
+        (is (= ":yolo\n" (rn (slurp out))))))
     (fs/delete out)
     (testing "depends"
       (test-utils/with-config {:tasks {'quux (list 'spit out "quux\n")
@@ -107,24 +119,6 @@
                                                 :task    (list 'spit out "foo\n" :append true)}}}
           (bb "foo")
           (is (= "quux\nbaz\nbar\nfoo\n" (slurp out))))))
-  (testing "init test"
-    (test-utils/with-config '{:tasks {:init (def x 1)
-                                      foo   x}}
-      (is (= 1 (bb "run" "--prn" "foo")))))
-  (testing "requires test"
-    (test-utils/with-config '{:tasks {:requires ([babashka.fs :as fs])
-                                      foo       (fs/exists? ".")}}
-      (is (= true (bb "run" "--prn" "foo"))))
-    (test-utils/with-config '{:tasks {foo {:requires ([babashka.fs :as fs])
-                                           :task     (fs/exists? ".")}}}
-      (is (= true (bb "run" "--prn" "foo"))))
-    (test-utils/with-config '{:tasks {bar {:requires ([babashka.fs :as fs])}
-                                      foo {:depends [bar]
-                                           :task    (fs/exists? ".")}}}
-      (is (= true (bb "run" "--prn" "foo")))))
-  (testing "map returned from task"
-    (test-utils/with-config '{:tasks {foo {:task {:a 1 :b 2}}}}
-      (is (= {:a 1 :b 2} (bb "run" "--prn" "foo")))))
   (testing "fully qualified symbol execution"
     (test-utils/with-config {:paths ["test-resources/task_scripts"]
                              :tasks '{foo tasks/foo}}
@@ -167,27 +161,27 @@
   (testing "no such task"
     (test-utils/with-config '{:tasks {a (+ 1 2 3)}}
       (is (thrown-with-msg?
-           Exception #"No such task: b"
-           (bb "run" "b")))))
+            Exception #"No such task: b"
+            (bb "run" "b")))))
   (testing "unresolved dependency"
     (test-utils/with-config '{:tasks {a (+ 1 2 3)
                                       b {:depends [x]
                                          :task    (+ a 4 5 6)}}}
       (is (thrown-with-msg?
-           Exception #"No such task: x"
-           (bb "run" "b")))))
+            Exception #"No such task: x"
+            (bb "run" "b")))))
   (testing "cyclic task"
     (test-utils/with-config '{:tasks {b {:depends [b]
                                          :task    (+ a 4 5 6)}}}
       (is (thrown-with-msg?
-           Exception #"Cyclic task: b"
-           (bb "run" "b"))))
+            Exception #"Cyclic task: b"
+            (bb "run" "b"))))
     (test-utils/with-config '{:tasks {c {:depends [b]}
                                       b {:depends [c]
                                          :task    (+ a 4 5 6)}}}
       (is (thrown-with-msg?
-           Exception #"Cyclic task: b"
-           (bb "run" "b")))))
+            Exception #"Cyclic task: b"
+            (bb "run" "b")))))
   (testing "doc"
     (test-utils/with-config '{:tasks {b {:doc "Beautiful docstring"}}}
       (let [s (test-utils/bb nil "doc" "b")]
@@ -196,25 +190,18 @@
     (test-utils/with-config '{:tasks {b (System/getProperty "babashka.task")}}
       (let [s (bb "run" "--prn" "b")]
         (is (= "b" s)))))
-  (testing "shell pipe test"
-    (test-utils/with-config '{:tasks {a (-> (shell {:out :string}
-                                                   "echo hello")
-                                            (shell {:out :string} "cat")
-                                            :out)}}
-      (let [s (bb "run" "--prn" "a")]
-        (is (= "hello\n" s)))))
   (testing "parallel test"
     (test-utils/with-config (edn/read-string (slurp "test-resources/coffee-tasks.edn"))
-      (let [tree [:made-coffee [[:ground-beans [:measured-beans]] [:heated-water [:poured-water]] :filter :mug]]
-            t0 (System/currentTimeMillis)
-            s (bb "run" "--prn" "coffeep")
-            t1 (System/currentTimeMillis)
+      (let [tree             [:made-coffee [[:ground-beans [:measured-beans]] [:heated-water [:poured-water]] :filter :mug]]
+            t0               (System/currentTimeMillis)
+            s                (bb "run" "--prn" "coffeep")
+            t1               (System/currentTimeMillis)
             delta-sequential (- t1 t0)]
         (is (= tree s))
         (test-utils/with-config (edn/read-string (slurp "test-resources/coffee-tasks.edn"))
-          (let [t0 (System/currentTimeMillis)
-                s (bb "run" "--parallel" "--prn" "coffeep")
-                t1 (System/currentTimeMillis)
+          (let [t0             (System/currentTimeMillis)
+                s              (bb "run" "--parallel" "--prn" "coffeep")
+                t1             (System/currentTimeMillis)
                 delta-parallel (- t1 t0)]
             (is (= tree s))
             (is (< delta-parallel delta-sequential))))))
@@ -224,40 +211,61 @@
                                               (throw (ex-info "0 noes" {})))
                                         c {:depends [a b]}}}
         (is (thrown-with-msg? Exception #"0 noes"
-                              (bb "run" "--parallel" "c")))))
+              (bb "run" "--parallel" "c")))))
     (testing "edge case"
       (test-utils/with-config '{:tasks
                                 {a   (run '-a {:parallel true})
                                  -a  {:depends [a:a a:b c]
-                                      :task (prn [a:a a:b c])}
+                                      :task    (prn [a:a a:b c])}
                                  a:a {:depends [c]
-                                      :task (+ 1 2 3)}
+                                      :task    (+ 1 2 3)}
                                  a:b {:depends [c]
-                                      :task (do (Thread/sleep 10)
-                                                (+ 1 2 3))}
-                                 c (do (Thread/sleep 10) :c)}}
+                                      :task    (do (Thread/sleep 10)
+                                                   (+ 1 2 3))}
+                                 c   (do (Thread/sleep 10) :c)}}
         (is (= [6 6 :c] (bb "run" "--prn" "a"))))))
   (testing "dynamic vars"
     (test-utils/with-config '{:tasks
                               {:init (def ^:dynamic *foo* true)
-                               a (do
-                                   (def ^:dynamic *bar* false)
-                                   (binding [*foo* false
-                                             *bar* true]
-                                     [*foo* *bar*]))}}
+                               a     (do
+                                       (def ^:dynamic *bar* false)
+                                       (binding [*foo* false
+                                                 *bar* true]
+                                         [*foo* *bar*]))}}
       (is (= [false true] (bb "run" "--prn" "a")))))
   (testing "stable namespace name"
     (test-utils/with-config '{:tasks
-                              {:init (do (def ^:dynamic *jdk*)
-                                         (def ^:dynamic *server*))
-                               server [*jdk* *server*]
-                               run-all (for [jdk [8 11 15]
+                              {:init   (do (def ^:dynamic *jdk*)
+                                           (def ^:dynamic *server*))
+                               server  [*jdk* *server*]
+                               run-all (for [jdk    [8 11 15]
                                              server [:foo :bar]]
-                                         (binding [*jdk* jdk
+                                         (binding [*jdk*    jdk
                                                    *server* server]
                                            (babashka.tasks/run 'server)))}}
       (is (= '([8 :foo] [8 :bar] [11 :foo] [11 :bar] [15 :foo] [15 :bar])
-             (bb "run" "--prn" "run-all"))))))
+            (bb "run" "--prn" "run-all"))))))
+
+
+(deftest ^:skip-windows unix-task-test
+  (let [tmp-dir (fs/create-temp-dir)
+        out     (str (fs/file tmp-dir "out.txt"))]
+    (testing "shell test with :continue"
+      (test-utils/with-config {:tasks {'foo (list 'shell {:out      out
+                                                          :err      out
+                                                          :continue true}
+                                              "ls foobar")}}
+        (bb "foo")
+        (is (str/includes? (slurp out)
+              "foobar"))))
+    (fs/delete out))
+  (testing "shell pipe test"
+    (test-utils/with-config '{:tasks {a (-> (shell {:out :string}
+                                              "echo hello")
+                                          (shell {:out :string} "cat")
+                                          :out)}}
+      (let [s (bb "run" "--prn" "a")]
+        (is (= "hello\n" s))))))
 
 (deftest list-tasks-test
   (test-utils/with-config {}

--- a/test/babashka/deps_test.clj
+++ b/test/babashka/deps_test.clj
@@ -42,14 +42,14 @@
 (babashka.deps/clojure [\"-P\"])
 true
 "))))
-  (is (= "6\n" (bb "
+  (is (= "6\n" (test-utils/normalize (bb "
 (require '[babashka.deps :as deps])
 (require '[babashka.process :as p])
 
 (-> (babashka.deps/clojure [\"-M\" \"-e\" \"(+ 1 2 3)\"] {:out :string})
     (p/check)
     :out)
-")))
+"))))
   (when-not test-utils/native?
     (is (thrown-with-msg? Exception #"Option changed" (bb "
 (require '[babashka.deps :as deps])

--- a/test/babashka/error_test.clj
+++ b/test/babashka/error_test.clj
@@ -40,7 +40,7 @@
 (defn foo [] (/ 1 0))
 (foo)")
                     (catch Exception e (ex-message e)))]
-    (is (str/includes? output "----- Stack trace --------------------------------------------------------------
+    (is (str/includes? (tu/normalize output) "----- Stack trace --------------------------------------------------------------
 clojure.core// - <built-in>
 user/foo       - <expr>:2:14
 user/foo       - <expr>:2:1
@@ -51,7 +51,7 @@ user           - <expr>:3:1"))))
 (defn foo [] (/ 1 0))
 (foo)")
                     (catch Exception e (ex-message e)))]
-    (is (str/includes? output "----- Context ------------------------------------------------------------------
+    (is (str/includes? (tu/normalize output) "----- Context ------------------------------------------------------------------
 1: 
 2: (defn foo [] (/ 1 0))
                 ^--- Divide by zero
@@ -60,14 +60,14 @@ user           - <expr>:3:1"))))
 (deftest parse-error-context-test
   (let [output (try (tu/bb nil "{:a}")
                     (catch Exception e (ex-message e)))]
-    (is (str/includes? output "----- Context ------------------------------------------------------------------
+    (is (str/includes? (tu/normalize output) "----- Context ------------------------------------------------------------------
 1: {:a}
    ^--- The map literal starting with :a contains 1 form(s)."))))
 
 (deftest jar-error-test
   (let [output (try (tu/bb nil "-cp" (.getPath (io/file "test-resources" "divide_by_zero.jar")) "-e" "(require 'foo)")
                     (catch Exception e (ex-message e)))]
-    (is (str/includes? output "----- Error --------------------------------------------------------------------
+    (is (str/includes? (tu/normalize output) "----- Error --------------------------------------------------------------------
 Type:     java.lang.ArithmeticException
 Message:  Divide by zero
 Location: foo.clj:1:10
@@ -83,7 +83,7 @@ foo            - foo.clj:1:10"))))
 (deftest static-call-test
   (let [output (try (tu/bb nil "-e" "File/x")
                     (catch Exception e (ex-message e)))]
-    (is (str/includes? output
+    (is (str/includes? (tu/normalize output)
                        "----- Error --------------------------------------------------------------------
 Type:     java.lang.IllegalArgumentException
 Message:  No matching field found: x for class java.io.File
@@ -97,7 +97,7 @@ Location: <expr>:1:1
 user - <expr>:1:1"))
     (let [output (try (tu/bb nil "-e" "(File/x)")
                       (catch Exception e (ex-message e)))]
-      (is (str/includes? output
+      (is (str/includes? (tu/normalize output)
                          "----- Error --------------------------------------------------------------------
 Type:     java.lang.IllegalArgumentException
 Message:  No matching method x found taking 0 args

--- a/test/babashka/impl/clojure/java/shell_test.clj
+++ b/test/babashka/impl/clojure/java/shell_test.clj
@@ -3,7 +3,7 @@
             [babashka.test-utils :as test-utils]
             [clojure.string :as str]))
 
-(deftest with-sh-env-test
+(deftest ^:skip-windows with-sh-env-test
   (is (= "\"BAR\""
          (str/trim (test-utils/bb nil "
 (-> (shell/with-sh-env {:FOO \"BAR\"}

--- a/test/babashka/impl/nrepl_server_test.clj
+++ b/test/babashka/impl/nrepl_server_test.clj
@@ -182,7 +182,7 @@
           (let [reply (read-reply in session @id)]
             (is (= "Hello\n" (tu/normalize (:out reply))))))))))
 
-(deftest nrepl-server-test
+(deftest ^:skip-windows nrepl-server-test
   (let [proc-state (atom nil)
         server-state (atom nil)]
     (try

--- a/test/babashka/test_utils.clj
+++ b/test/babashka/test_utils.clj
@@ -13,16 +13,15 @@
 
 (set! *warn-on-reflection* true)
 
+(defn string-replace-if-windows [match replacement]
+  (fn [s]
+    (if main/windows?
+      (str/replace s match replacement)
+      s)))
 
-(defn normalize [s]
-  (if main/windows?
-    (str/replace s "\r\n" "\n")
-    s))
+(def normalize (string-replace-if-windows "\r\n" "\n"))
 
-(defn escape-file-paths [s]
-  (if main/windows?
-    (str/replace s "\\" "\\\\")
-    s))
+(def escape-file-paths (string-replace-if-windows "\\" "\\\\"))
 
 (def ^:dynamic *bb-edn-path* nil)
 

--- a/test/babashka/transit_test.clj
+++ b/test/babashka/transit_test.clj
@@ -10,4 +10,4 @@
 (deftest transit-test
   (is (= "\"foo\"\n{:a [1 2]}\n"
          (bb (format "(load-file \"%s\")"
-                     (.getPath (io/file "test-resources" "babashka" "transit.clj")))))))
+               (test-utils/escape-file-paths (.getPath (io/file "test-resources" "babashka" "transit.clj"))))))))

--- a/test/babashka/uberjar_test.clj
+++ b/test/babashka/uberjar_test.clj
@@ -1,8 +1,9 @@
 (ns babashka.uberjar-test
   (:require
-   [babashka.test-utils :as tu]
-   [clojure.string :as str]
-   [clojure.test :as t :refer [deftest is testing]]))
+    [babashka.test-utils :as tu]
+    [clojure.string :as str]
+    [clojure.test :as t :refer [deftest is testing]]
+    [babashka.main :as main]))
 
 (defn count-entries [jar]
   (with-open [jar-file (java.util.jar.JarFile. jar)]
@@ -53,8 +54,9 @@
            (tu/bb nil "uberjar" path "-m" "my.main-main")))))
   (testing "ignore empty entries on classpath"
     (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
-          path (.getPath tmp-file)]
+          path (.getPath tmp-file)
+          empty-classpath (if main/windows? ";;;" ":::")]
       (.deleteOnExit tmp-file)
-      (tu/bb nil "--classpath" ":::" "uberjar" path "-m" "my.main-main")
+      (tu/bb nil "--classpath" empty-classpath "uberjar" path "-m" "my.main-main")
       ;; Only a manifest entry is added
       (is (< (count-entries path) 3)))))

--- a/test/babashka/uberjar_test.clj
+++ b/test/babashka/uberjar_test.clj
@@ -12,7 +12,7 @@
                 (enumeration-seq
                  (.entries jar-file))))))
 
-(deftest uberjar-test
+(deftest ^:skip-windows uberjar-test
   (testing "uberjar with --main"
     (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
           path (.getPath tmp-file)]

--- a/test/babashka/udp_test.clj
+++ b/test/babashka/udp_test.clj
@@ -22,4 +22,4 @@
              "-e" "(load-file (io/file \"test-resources\" \"babashka\" \"statsd.clj\"))"
              "-e" "(require '[statsd-client :as c])"
              "-e" "(c/increment :foo)"))
-    (is (= ":foo:1|c\n" (str sw)))))
+    (is (= ":foo:1|c\n" (tu/normalize (str sw))))))


### PR DESCRIPTION
this is kind of a big PR in my mind, so I apologize for that, but a large amount of the change is 'swapping' :windows and :skip-windows

- change from selecting tests to run to selecting tests to skip (remove all :windows tags, add
  :skip-windows tag to tests that don't currently work on windows)
- handfuls of calls to `normalize` and `escape-file-paths` to handle platform differences
- split `b.bb-edn-test/task-test` to make most of the tests run on windows, and exclude just a couple of Unix-y tests

I think the difference between Windows tests and Linux tests is now something like 10-15 assertions, but one of the big ones is the pods test, so if it's ok with you, I'd like to take some time and maybe play around with making the pod test work on Windows JVM (it works as a native test). I'd also like to (maybe) write a couple tests aimed specifically at Windows (to account for the existing Unix-y tests), and add a default test selector to skip ":windows-only" or something like that... what do you think?