### PR TITLE
add more windows testing (#235)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
   ;; :java-source-paths ["sci/reflector/src-java"]
   :java-source-paths ["src-java"]
   :resource-paths ["resources" "sci/resources"]
-  :test-selectors {:windows (complement :skip-windows)}
+  :test-selectors {:default (complement :windows-only)
+                   :windows (complement :skip-windows)}
   :dependencies [[org.clojure/clojure "1.11.0-alpha1"]
                  [borkdude/edamame "0.0.11"]
                  [borkdude/graal.locking "0.0.2"]

--- a/script/test.bat
+++ b/script/test.bat
@@ -34,9 +34,8 @@ set BABASHKA_CLASSPATH=test-resources/babashka/src_for_classpath_test/env
 echo "running tests part 4"
 call lein test :only babashka.classpath-test/classpath-env-test || exit /B 1
 
-echo "not running pod tests on windows (yet)"
-REM set BABASHKA_POD_TEST=true
-REM call lein test :only babashka.pod-test || exit /B 1
+set BABASHKA_POD_TEST=true
+call lein test :only babashka.pod-test || exit /B 1
 
 set BABASHKA_SOCKET_REPL_TEST=true
 call lein test :only babashka.impl.socket-repl-test || exit /B 1

--- a/test-resources/pod.clj
+++ b/test-resources/pod.clj
@@ -128,10 +128,12 @@
   (if (contains? cli-args "--run-as-pod")
     (do (debug "running pod with cli args" cli-args)
         (run-pod cli-args))
-    (let [native? (contains? cli-args "--native")]
-      (pods/load-pod (if native?
-                       (into ["./bb" "test-resources/pod.clj" "--run-as-pod"] cli-args)
-                       (into ["lein" "bb" "test-resources/pod.clj" "--run-as-pod"] cli-args)))
+    (let [native? (contains? cli-args "--native")
+          windows? (contains? cli-args "--windows")]
+      (pods/load-pod (cond
+                       native?  (into ["./bb" "test-resources/pod.clj" "--run-as-pod"] cli-args)
+                       windows? (into ["cmd" "/c" "lein" "bb" "test-resources/pod.clj" "--run-as-pod"] cli-args)
+                       :else    (into ["lein" "bb" "test-resources/pod.clj" "--run-as-pod"] cli-args)))
       (require '[pod.test-pod])
       (if (contains? cli-args "--json")
         (do

--- a/test/babashka/impl/clojure/java/shell_test.clj
+++ b/test/babashka/impl/clojure/java/shell_test.clj
@@ -1,7 +1,9 @@
 (ns babashka.impl.clojure.java.shell-test
-  (:require [clojure.test :as t :refer [deftest is testing]]
+  (:require [babashka.main :as main]
             [babashka.test-utils :as test-utils]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.test :as t :refer [deftest is testing]]))
+
 
 (deftest ^:skip-windows with-sh-env-test
   (is (= "\"BAR\""
@@ -15,3 +17,17 @@
       (shell/sh \"ls\"))
     :out)"))
                      "icon.svg")))
+
+(deftest ^:windows-only win-with-sh-env-test
+  (when main/windows?
+    (is (= "\"BAR\""
+          (str/trim (test-utils/bb nil "
+(-> (shell/with-sh-env {:FOO \"BAR\"}
+      (shell/sh \"cmd\" \"/c\" \"echo %FOO%\"))
+    :out
+    str/trim)"))))
+    (is (str/includes? (str/trim (test-utils/bb nil "
+(-> (shell/with-sh-dir \"logo\"
+      (shell/sh \"cmd\" \"/c\" \"dir\"))
+    :out)"))
+          "icon.svg"))))

--- a/test/babashka/pod_test.clj
+++ b/test/babashka/pod_test.clj
@@ -1,23 +1,29 @@
 (ns babashka.pod-test
-  (:require [babashka.test-utils :as tu]
+  (:require [babashka.main :as main]
+            [babashka.test-utils :as tu]
             [clojure.edn :as edn]
             [clojure.test :as t :refer [deftest is]]))
 
 (deftest pod-test
   (if (= "true" (System/getenv "BABASHKA_POD_TEST"))
     (let [native? tu/native?
+          windows? main/windows?
           sw (java.io.StringWriter.)
           res (apply tu/bb {:err sw}
                      (cond-> ["-f" "test-resources/pod.clj"]
                        native?
-                       (conj "--native")))
+                       (conj "--native")
+                       windows?
+                       (conj "--windows")))
           err (str sw)]
       (is (= "6\n1\n2\n3\n4\n5\n6\n7\n8\n9\n\"Illegal arguments / {:args (1 2 3)}\"\n(\"hello\" \"print\" \"this\" \"debugging\" \"message\")\ntrue\n" res))
       (when-not tu/native?
-        (is (= "(\"hello\" \"print\" \"this\" \"error\")\n" err)))
+        (is (= "(\"hello\" \"print\" \"this\" \"error\")\n" (tu/normalize err))))
       (is (= {:a 1 :b 2}
              (edn/read-string
               (apply tu/bb nil (cond-> ["-f" "test-resources/pod.clj" "--json"]
                                  native?
-                                 (conj "--native")))))))
+                                 (conj "--native")
+                                 windows?
+                                 (conj "--windows")))))))
     (println "Skipping pod test because BABASHKA_POD_TEST isn't set to true.")))

--- a/test/babashka/uberjar_test.clj
+++ b/test/babashka/uberjar_test.clj
@@ -12,7 +12,7 @@
                 (enumeration-seq
                  (.entries jar-file))))))
 
-(deftest ^:skip-windows uberjar-test
+(deftest uberjar-test
   (testing "uberjar with --main"
     (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
           path (.getPath tmp-file)]
@@ -45,13 +45,16 @@
         (is (= "(\"42\")\n" (tu/bb nil "--jar" path "-m" "my.main-main" "42")))
         (is (= "(\"42\")\n" (tu/bb nil "--classpath" path "-m" "my.main-main" "42")))
         (is (= "(\"42\")\n" (tu/bb nil path "42"))))))
-  (testing "throw on empty classpath"
-    (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
-          path (.getPath tmp-file)]
-      (.deleteOnExit tmp-file)
-      (is (thrown-with-msg?
-           Exception #"classpath"
-           (tu/bb nil "uberjar" path "-m" "my.main-main")))))
+
+  ; this test fails the windows native test in CI
+  (when-not main/windows?
+    (testing "throw on empty classpath"
+      (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
+            path     (.getPath tmp-file)]
+        (.deleteOnExit tmp-file)
+        (is (thrown-with-msg?
+              Exception #"classpath"
+              (tu/bb nil "uberjar" path "-m" "my.main-main"))))))
   (testing "ignore empty entries on classpath"
     (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
           path (.getPath tmp-file)


### PR DESCRIPTION
- add default test selector to skip "windows only" tests
- in cases where the differences between *nix shell and windows shell
  make the test very messy, add a separate "windows only" test
- make more tests work on Windows

all my local CI testing passes, but I guess we'll see if AppVeyor agrees with that assessment