### PR TITLE
fix windows lib tests (#940)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ build_script:
 
     call script/test.bat
 
-# call script/run_lib_tests.bat
+    call script/run_lib_tests.bat
 
 artifacts:
 - path: babashka-*-windows-amd64.zip

--- a/deps.edn
+++ b/deps.edn
@@ -50,7 +50,7 @@
                        "-Dclojure.compiler.direct-linking=true"]
             :main-opts ["-m" "babashka.profile"]}
            :lib-tests
-           {:extra-paths ["process/src" "process/test"]
+           {:extra-paths ["process/src" "process/test" "test-resources/lib_tests"]
             :extra-deps {babashka/clj-http-lite
                          {:git/url "https://github.com/babashka/clj-http-lite"
                           :sha "f44ebe45446f0f44f2b73761d102af3da6d0a13e"}

--- a/script/lib_tests/bb_edn_from_deps.clj
+++ b/script/lib_tests/bb_edn_from_deps.clj
@@ -1,0 +1,20 @@
+(ns bb_edn_from_deps
+  (:require [clojure.edn :as edn]
+            [clojure.set :as set]))
+
+(defn select-deps [m] (select-keys m [:paths :deps]))
+
+(defn extra-deps [m]
+  (-> m
+    (get-in [:aliases :lib-tests])
+    (set/rename-keys {:extra-deps  :deps
+                      :extra-paths :paths})
+    select-deps))
+
+(if (seq *command-line-args*)
+  (->> (slurp "deps.edn")
+    edn/read-string
+    ((juxt select-deps extra-deps))
+    (apply merge-with into)
+    (spit (first *command-line-args*)))
+  (println "Please specify an output file"))

--- a/script/lib_tests/run_all_libtests
+++ b/script/lib_tests/run_all_libtests
@@ -11,5 +11,5 @@ fi
 export BABASHKA_CLASSPATH
 BABASHKA_CLASSPATH=$(clojure -A:lib-tests -Spath)
 
-$BB_CMD -cp "$BABASHKA_CLASSPATH:test-resources/lib_tests" \
+$BB_CMD -cp "$BABASHKA_CLASSPATH" \
         -f "test-resources/lib_tests/babashka/run_all_libtests.clj" "$@"

--- a/script/lib_tests/run_all_libtests.bat
+++ b/script/lib_tests/run_all_libtests.bat
@@ -1,5 +1,11 @@
 if "%BABASHKA_TEST_ENV%" EQU "native" (set BB_CMD=.\bb) else (set BB_CMD=lein bb)
 
-for /f %%i in ('.\bb clojure -A:lib-tests -Spath') do set BABASHKA_CLASSPATH=%%i
+set EDN=lib_tests.edn
 
-%BB_CMD% -cp "%BABASHKA_CLASSPATH%;test-resources/lib_tests" -f test-resources/lib_tests/babashka/run_all_libtests.clj %*
+.\bb -f script/lib_tests/bb_edn_from_deps.clj %EDN%
+
+set BABASHKA_EDN=%EDN%
+
+%BB_CMD% -f test-resources/lib_tests/babashka/run_all_libtests.clj %*
+
+set BABASHKA_EDN=


### PR DESCRIPTION
- add lib-tests path to deps.edn and remove it from shell scripts
- change windows lib test batch script to write a bb.edn file
- re-enable native lib tests on windows

things are working locally, and the main reliance on the windows stuff is environment variables, and not capturing command output

in my local testing, the (native) lib tests run in about 30 seconds, so I don't imagine these will add a ton of time to the build