### PR TITLE
add META-INF resource to windows compilation (fixes #963)

### DIFF
--- a/script/compile.bat
+++ b/script/compile.bat
@@ -31,6 +31,7 @@ call %GRAALVM_HOME%\bin\native-image.cmd ^
   "-J-Dclojure.compiler.direct-linking=true" ^
   "-H:IncludeResources=BABASHKA_VERSION" ^
   "-H:IncludeResources=SCI_VERSION" ^
+  "-H:IncludeResources=META-INF/babashka/.*" ^
   "-H:ReflectionConfigurationFiles=reflection.json" ^
   "--initialize-at-build-time"  ^
   "--initialize-at-run-time=org.postgresql.sspi.SSPIClient" ^

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -34,7 +34,7 @@
       (is (= "src"
              (bb "-cp" "src" "-e" "(babashka.classpath/get-classpath)"))))))
 
-(deftest ^:skip-windows print-deps-test
+(deftest print-deps-test
   (test-utils/with-config '{:deps {medley/medley {:mvn/version "1.3.0"}}}
     (testing "deps output"
       (let [edn (bb "print-deps")


### PR DESCRIPTION
It looks like the deps.edn resource that got added to `compile` just needs to get added to `compile.bat` as well. This made the test pass immediately in my local env.