### PR TITLE
varify some core dynamic vars (#957)

### DIFF
--- a/src/babashka/impl/clojure/core.clj
+++ b/src/babashka/impl/clojure/core.clj
@@ -7,8 +7,8 @@
             [clojure.core :as c]
             [clojure.string :as str]
             [sci.core :as sci]
-            [sci.impl.namespaces :refer [copy-core-var clojure-core-ns]]
-            [sci.impl.vars :as vars]))
+            [sci.impl.namespaces :refer [copy-core-var]]
+            [sci.impl.vars :as vars :refer [clojure-core-ns]]))
 
 (defn locking* [form bindings v f & args]
   (apply @#'locking/locking form bindings v f args))

--- a/src/babashka/impl/clojure/core.clj
+++ b/src/babashka/impl/clojure/core.clj
@@ -22,10 +22,14 @@
      (prn (str "Elapsed time: " (/ (double (- (. System (nanoTime)) start#)) 1000000.0) " msecs"))
      ret#))
 
-(def data-readers (sci/new-dynamic-var '*data-readers* nil))
-(def command-line-args (sci/new-dynamic-var '*command-line-args* nil))
-(def warn-on-reflection (sci/new-dynamic-var '*warn-on-reflection* false))
-(def math-context (sci/new-dynamic-var '*math-context* nil))
+(defn core-dynamic-var
+  ([sym] (core-dynamic-var sym nil))
+  ([sym init-val] (sci/new-dynamic-var sym init-val {:ns clojure-core-ns})))
+
+(def data-readers (core-dynamic-var '*data-readers*))
+(def command-line-args (core-dynamic-var '*command-line-args*))
+(def warn-on-reflection (core-dynamic-var '*warn-on-reflection* false))
+(def math-context (core-dynamic-var '*math-context*))
 
 ;; (def major (:major *clojure-version*))
 ;; (def minor (:minor *clojure-version*))


### PR DESCRIPTION
- refer to `clojure-core-ns` from `sci.impl.vars` instead of `sci.impl.namespaces` (continuation of borkdude/sci#597)
- add `:ns` meta to core dynamic vars (much like the dynamic vars from `sci.impl.io`)