### PR TITLE
test that var metadata matches containing ns

### DIFF
--- a/feature-jdbc/babashka/impl/jdbc.clj
+++ b/feature-jdbc/babashka/impl/jdbc.clj
@@ -2,7 +2,7 @@
   {:no-doc true}
   (:require [next.jdbc :as njdbc]
             [next.jdbc.sql :as sql]
-            [sci.impl.namespaces :refer [copy-var]]
+            [sci.impl.namespaces :refer [copy-var macrofy]]
             [sci.impl.vars :as vars]))
 
 (def next-ns (vars/->SciNamespace 'next.jdbc nil))
@@ -28,8 +28,7 @@
    'plan (copy-var njdbc/plan next-ns)
    'prepare (copy-var njdbc/prepare next-ns)
    'transact (copy-var njdbc/transact next-ns)
-   'with-transaction (with-meta with-transaction
-                       {:sci/macro true})})
+   'with-transaction (macrofy 'with-transaction with-transaction next-ns)})
 
 (def sns (vars/->SciNamespace 'next.jdbc.sql nil))
 

--- a/feature-test-check/babashka/impl/clojure/test/check.clj
+++ b/feature-test-check/babashka/impl/clojure/test/check.clj
@@ -174,4 +174,4 @@
     (println (str "'" k) (format "(sci/copy-var tc/%s p-ns)" k)))
 
 (def test-check-namespace
-  {'quick-check (sci/copy-var tc/quick-check p-ns)})
+  {'quick-check (sci/copy-var tc/quick-check tc-ns)})

--- a/test/babashka/namespace_test.clj
+++ b/test/babashka/namespace_test.clj
@@ -1,0 +1,25 @@
+(ns babashka.namespace-test
+  (:require [babashka.test-utils :as tu]
+            [clojure.edn :as edn]
+            [clojure.test :refer :all]))
+
+(defn bb [input & args]
+  (edn/read-string
+      {:readers *data-readers*
+       :eof nil}
+      (apply tu/bb (when (some? input) (str input)) (map str args))))
+
+(deftest publics-namespace-test
+  (testing "all namespace publics (except for those in clojure.lang and user namespaces)
+            have ns metadata that matches the namespace it's in"
+    (comment "results seq contains vars whose ns meta doesn't match the ns they're in")
+    (is (empty? (bb nil "
+(let [excluded-namespaces #{'clojure.lang 'user}]
+  (for [nspace              (remove #(excluded-namespaces (ns-name %)) (all-ns))
+        [var-symbol ns-var] (ns-publics nspace)
+        :let                [ns-ns-name  (ns-name nspace)
+                             var-ns-name (some-> ns-var meta :ns ns-name)]
+        :when               (not= ns-ns-name var-ns-name)]
+    {:containing-ns ns-ns-name
+     :ns-on-var     var-ns-name
+     :var-name      var-symbol}))")))))


### PR DESCRIPTION
- `quick-check`'s metadata had its ns as `clojure.test.check.properties`, but is in `clojure.test.check`, so change that meta
- add `namespace-test` to test that all the public vars have `:ns` metadata, and that it matches their containing namespace (checking that ns names are equal, not that they're identical, because the features don't currently have identical namespaces)

I would say, at your discretion, this might be sufficient to close out #957 - the only vars that don't have `:ns` in their meta now are the `clojure.lang` ones and `*input*`