### PR TITLE
add lib test and an example for multigrep (#461)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -87,6 +87,7 @@
                          com.grammarly/omniconf {:mvn/version "0.4.3"}
                          crispin/crispin {:mvn/version "0.3.8"}
                          org.clojure/data.json {:mvn/version "2.4.0"}
+                         clj-commons/multigrep {:mvn/version "0.5.0"}
                          amperity/vault-clj {:mvn/version "1.0.4"}}
            :classpath-overrides {org.clojure/clojure nil
                                  org.clojure/spec.alpha nil

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -44,6 +44,7 @@ The following libraries and projects are known to work with babashka.
     - [hasch](#hasch)
     - [crispin](#crispin)
     - [ffclj](#ffclj)
+    - [multigrep](#multigrep)
   - [Pods](#pods)
   - [Projects](#projects-1)
     - [babashka-test-action](#babashka-test-action)
@@ -632,6 +633,44 @@ FOO=1 script.clj
 ### [ffclj](https://github.com/luissantos/ffclj)
 
 A wrapper around executing `ffmpeg` and `ffprobe`. Supports progress reporting via core.async channels.
+
+### [multigrep](https://github.com/clj-commons/multigrep)
+
+Regex-based file grepping and/or text substitution.
+
+Example:
+- find the words that are exactly four letters long in some strings:
+```clj
+(ns multigrep-demo
+  (:require [babashka.deps :as deps]
+            [clojure.pprint :refer [pprint]])
+  (:import (java.io StringReader)))
+
+(deps/add-deps '{:deps {clj-commons/multigrep {:mvn/version "0.5.0"}}})
+
+(require '[multigrep.core :as grep])
+
+; the StringReaders could be anything that clojure.java.io/reader will accept (files, URLs, etc.)
+(let [sentence1 (StringReader. "the quick brown fox jumps over the lazy dog")
+      sentence2 (StringReader. "Lorem ipsum dolor sit amet")]
+  (pprint (grep/grep #"\b[a-z]{4}\b" [sentence1 sentence2])))
+```
+
+outputs:
+```
+({:file
+  #object[java.io.StringReader...],
+  :line "the quick brown fox jumps over the lazy dog",
+  :line-number 1,
+  :regex #"\b[a-z]{4}\b",
+  :re-seq ("over" "lazy")}
+ {:file
+  #object[java.io.StringReader...],
+  :line "Lorem ipsum dolor sit amet",
+  :line-number 1,
+  :regex #"\b[a-z]{4}\b",
+  :re-seq ("amet")})
+```
 
 ## Pods
 

--- a/feature-lanterna/babashka/impl/lanterna.clj
+++ b/feature-lanterna/babashka/impl/lanterna.clj
@@ -8,7 +8,7 @@
 
 (def tns (sci/create-ns 'lanterna.terminal nil))
 (def sns (sci/create-ns 'lanterna.screen nil))
-(def cns (sci/create-ns 'lanterna.screen nil))
+(def cns (sci/create-ns 'lanterna.constants nil))
 
 (def lanterna-terminal-namespace
   {'add-resize-listener (copy-var lanterna.terminal/add-resize-listener tns)

--- a/test-resources/lib_tests/babashka/run_all_libtests.clj
+++ b/test-resources/lib_tests/babashka/run_all_libtests.clj
@@ -237,6 +237,8 @@
 (test-namespaces 'clojure.data.json-test
                  'clojure.data.json-test-suite-test)
 
+(test-namespaces 'multigrep.core-test)
+
 (test-namespaces
  ;; TODO: env tests don't work because envoy lib isn't compatible with bb
  #_'vault.env-test

--- a/test-resources/lib_tests/multigrep/core_test.clj
+++ b/test-resources/lib_tests/multigrep/core_test.clj
@@ -1,0 +1,23 @@
+(ns multigrep.core-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [multigrep.core :as grep])
+  (:import (java.io StringReader)))
+
+(def lorem-ipsum "Lorem ipsum dolor sit amet, consectetur adipiscing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.")
+
+(deftest single-regex-test
+  (testing "single regex, single text source"
+    (let [result (grep/grep #"t[,.]" (StringReader. lorem-ipsum))]
+      (is (= [1 2 4 6] (mapv :line-number result))))))
+
+(deftest multi-regex-test
+  (testing "multiple regexes, multiple text sources"
+    (let [result (grep/grep [#"t[,.]" #"s\s"] [(StringReader. lorem-ipsum) (io/resource "multigrep/haiku.txt")])]
+      (is (= 8 (count result))))))

--- a/test-resources/lib_tests/multigrep/haiku.txt
+++ b/test-resources/lib_tests/multigrep/haiku.txt
@@ -1,0 +1,3 @@
+haikus are easy
+but sometimes they make no sense
+refrigerator


### PR DESCRIPTION
this change also corrects the name of the `lanterna.constants` namespace