### PR TITLE
script: use musl from bullseye instead of unstable

### DIFF
--- a/script/setup-musl
+++ b/script/setup-musl
@@ -12,13 +12,14 @@ if [[ -z "${BABASHKA_MUSL:-}" ]]; then
     exit 0
 fi
 
-# This script sets up the latest available musl-tools using apt pinning from debian unstable.
-# The one available in stable and testing are quite outdated and this ensures we get the latest improvements
-# This explictly installs musl from unstable and keeps the others at a higher priority
+# This script sets up the latest available musl-tools using apt pinning from Debian bullseye (11).
+# The one available in stretch (Debian 9) is outdated and this ensures we get the latest improvements
+# This explictly installs musl from bullseye and keeps the others at a higher priority
+# TODO: remove after clojure image is updated to bullseye
 
 cat >> /etc/apt/sources.list <<eof
-deb http://ftp.us.debian.org/debian unstable main non-free contrib
-deb http://non-us.debian.org/debian-non-us unstable/non-us main contrib non-free
+deb http://ftp.us.debian.org/debian bullseye main non-free contrib
+deb http://non-us.debian.org/debian-non-us bullseye/non-us main contrib non-free
 eof
 
 cat >> /etc/apt/preferences <<eof
@@ -29,11 +30,11 @@ Package: *
 Pin: release a=testing
 Pin-Priority: 650
 Package: *
-pin: release a=unstable
+pin: release a=bullseye
 pin-priority: 600
 eof
 
-apt-get update -y && apt-get install musl-tools/unstable -y
+apt-get update -y && apt-get install musl-tools/bullseye -y
 
 ZLIB_VERSION="1.2.11"
 


### PR DESCRIPTION
Now that bullseye was released, Debian is starting to make bigger changes on unstable. To avoid breakage, let's use musl from bullseye that is the correct version that we were using until now (1.22-1): https://packages.debian.org/bullseye/musl-tools

Eventually a better solution would be to simply use Debian bullseye to compile everything, however the official Clojure image from Docker is still using stretch. So this is a temporary solution until them.

Fix issue: https://github.com/babashka/babashka/pull/972