### PR TITLE
use tagged-literal for unknown EDN tags when creating *input* (#975)

### DIFF
--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -424,7 +424,7 @@ Use bb run --help to show this help output.
 
 (defn edn-seq*
   [^java.io.BufferedReader rdr]
-  (let [edn-val (edn/read {:eof ::EOF :readers edn-readers} rdr)]
+  (let [edn-val (edn/read {:eof ::EOF :readers edn-readers :default tagged-literal} rdr)]
     (when (not (identical? ::EOF edn-val))
       (cons edn-val (lazy-seq (edn-seq* rdr))))))
 
@@ -676,6 +676,7 @@ Use bb run --help to show this help output.
                           (if stream?
                             (if shell-in (or (read-line) ::EOF)
                                 (edn/read {:readers edn-readers
+                                           :default tagged-literal
                                            :eof ::EOF} *in*))
                             (delay (cond shell-in
                                          (shell-seq *in*)

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -683,7 +683,8 @@ Use bb run --help to show this help output.
                                          edn-in
                                          (edn-seq *in*)
                                          :else
-                                         (edn/read {:readers edn-readers} *in*))))))
+                                         (edn/read {:readers edn-readers
+                                                    :default tagged-literal} *in*))))))
             uberscript-sources (atom ())
             classpath (or classpath
                           (System/getenv "BABASHKA_CLASSPATH"))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -733,7 +733,13 @@ true")))
             (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "-I" "(map :a *input*)")))))
     (testing "when using --stream and -I"
       (is (= "#abc 123\n#cde 789\n"
-            (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "--stream" "-I" "-e" "(println (:a *input*))")))))))
+            (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "--stream" "-I" "-e" "(println (:a *input*))")))))
+    (testing "when using --stream (-I is sort of implied if no -i)"
+      (is (= "#abc 123\n#cde 789\n"
+            (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "--stream" "-e" "(println (:a *input*))")))))
+    (testing "when reading one EDN form from stdin (no --stream or -I or -i)"
+      (is (= "#abc 123\n"
+            (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "-e" "(println (:a *input*))")))))))
 
 ;;;; Scratch
 

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -719,6 +719,22 @@ true")))
     (let [first-doc (test-utils/bb nil "(doc first)")]
         (is (every? #(str/includes? first-doc %) ["---" "clojure.core/first" "first item"])))))
 
+(deftest edn-input-test
+  (testing "clojure's default readers"
+    (is (= '(#inst "2021-08-24T00:56:02.014-00:00")
+          (bb "#inst \"2021-08-24T00:56:02.014-00:00\"" "-I" "(println *input*)")))
+    (is (= '(#uuid "00000000-0000-0000-0000-000000000000")
+          (bb "#uuid \"00000000-0000-0000-0000-000000000000\"" "-I" "(println *input*)"))))
+  (testing "use tagged-literal as default data reader fn..."
+    (testing "when using the -I option"
+      (is (= "(#made-up-tag 42)\n"
+            (test-utils/normalize (test-utils/bb "#made-up-tag 42" "-I" "(println *input*)"))))
+      (is (= "(#abc 123 #cde 789)\n"
+            (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "-I" "(map :a *input*)")))))
+    (testing "when using --stream and -I"
+      (is (= "#abc 123\n#cde 789\n"
+            (test-utils/normalize (test-utils/bb "{:a #abc 123}{:a #cde 789}" "--stream" "-I" "-e" "(println (:a *input*))")))))))
+
 ;;;; Scratch
 
 (comment


### PR DESCRIPTION
just adding `:default` to all the places where we use `edn/read` to populate `*input*`