### PR TITLE
Add WebSocket support.

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -186,6 +186,7 @@
           jdk.internal.net.http.HttpResponseImpl
           jdk.internal.net.http.common.MinimalFuture
           jdk.internal.net.http.websocket.BuilderImpl
+          jdk.internal.net.http.websocket.WebSocketImpl
           java.net.http.HttpClient
           java.net.http.HttpClient$Builder
           java.net.http.HttpClient$Redirect

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -181,10 +181,11 @@
           java.net.URLDecoder
           ;; java.net.http
           jdk.internal.net.http.HttpClientBuilderImpl
-          jdk.internal.net.http.HttpRequestBuilderImpl
-          jdk.internal.net.http.common.MinimalFuture
           jdk.internal.net.http.HttpClientFacade
+          jdk.internal.net.http.HttpRequestBuilderImpl
           jdk.internal.net.http.HttpResponseImpl
+          jdk.internal.net.http.common.MinimalFuture
+          jdk.internal.net.http.websocket.BuilderImpl
           java.net.http.HttpClient
           java.net.http.HttpClient$Builder
           java.net.http.HttpClient$Redirect

--- a/src/babashka/impl/reify.clj
+++ b/src/babashka/impl/reify.clj
@@ -148,6 +148,15 @@
     {iterator [[this]]
      forEach  [[this action]]}
 
+    java.net.http.WebSocket$Listener
+    {onBinary [[this ws data last?]]
+     onClose [[this ws status-code reason]]
+     onError [[this ws error]]
+     onOpen [[this ws]]
+     onPing [[this ws data]]
+     onPong [[this ws data]]
+     onText [[this ws data last?]]}
+
     java.util.Iterator
     {hasNext [[this]]
      next    [[this]]}

--- a/test/babashka/java_http_client_test.clj
+++ b/test/babashka/java_http_client_test.clj
@@ -310,7 +310,8 @@
                    handler (HttpResponse$BodyHandlers/discarding)
                    no-auth-res (.send no-auth-client req handler)
                    authenticator (proxy [Authenticator] []
-                                   (getPasswordAuthentication [] (PasswordAuthentication. "postman" (char-array "password"))))
+                                   (getPasswordAuthentication []
+                                     (PasswordAuthentication. "postman" (char-array "password"))))
                    auth-client (-> (HttpClient/newBuilder)
                                    (.authenticator authenticator)
                                    (.build))

--- a/test/babashka/java_http_client_test.clj
+++ b/test/babashka/java_http_client_test.clj
@@ -3,7 +3,8 @@
    [babashka.test-utils :as test-utils]
    [clojure.edn :as edn]
    [clojure.string :as str]
-   [clojure.test :as test :refer [deftest is]]))
+   [clojure.test :as test :refer [deftest is]]
+   [org.httpkit.server :as httpkit.server]))
 
 (defn bb [expr]
   (edn/read-string (apply test-utils/bb nil [(str expr)])))
@@ -416,3 +417,47 @@
                    temp-file-path (str (.body res))
                    contents (slurp temp-file-path)]
                (str/includes? contents "babashka")))))))
+
+(defn ws-handler [{:keys [init] :as opts} req]
+  (when init (init req))
+  (httpkit.server/as-channel
+    req
+    (select-keys opts [:on-close :on-ping :on-receive])))
+
+(def ^:dynamic *ws-port* 1234)
+
+(defmacro with-ws-server
+  [opts & body]
+  `(let [s# (httpkit.server/run-server (partial ws-handler ~opts) {:port ~*ws-port*})]
+     (try ~@body (finally (s# :timeout 100)))))
+
+(deftest websockets-test
+  (with-ws-server {:on-receive #(httpkit.server/send! %1 %2)}
+    (is (= "zomg websockets!"
+           (bb
+            '(do
+               (ns net
+                 (:require
+                  [clojure.string :as str])
+                 (:import
+                  (java.net URI)
+                  (java.net.http HttpClient
+                                 WebSocket$Listener)
+                  (java.util.concurrent CompletableFuture)
+                  (java.util.function Function)))
+               (let [p (promise)
+                     uri (URI. "ws://localhost:1234")
+                     listener (reify WebSocket$Listener
+                                (onOpen [_ ws]
+                                  (.request ws 1))
+                                (onText [_ ws data last?]
+                                  (.request ws 1)
+                                  (.thenApply (CompletableFuture/completedFuture nil)
+                                              (reify Function
+                                                (apply [_ _] (deliver p (str data)))))))
+                     client (HttpClient/newHttpClient)
+                     ws (-> (.newWebSocketBuilder client)
+                            (.buildAsync uri listener)
+                            (deref))]
+                 (.sendText ws "zomg websockets!" true)
+                 (deref p 5000 ::timeout))))))))

--- a/test/babashka/java_http_client_test.clj
+++ b/test/babashka/java_http_client_test.clj
@@ -362,6 +362,7 @@
                       (map (fn [[k req]]
                              [k (send-and-catch client req handler)]))
                       (into {})))))))))
+
 (deftest request-timeout-test
   (is (= "java.net.http.HttpTimeoutException"
          (bb

--- a/test/babashka/java_http_client_test.clj
+++ b/test/babashka/java_http_client_test.clj
@@ -151,6 +151,29 @@
                     res (.send client req (HttpResponse$BodyHandlers/discarding))]
                 (.statusCode res)))))))
 
+(deftest ssl-test
+  (is (= 200
+         (bb
+           '(do
+              (ns net
+                (:import
+                 (java.net URI)
+                 (java.net.http HttpClient
+                                HttpRequest
+                                HttpResponse$BodyHandlers)
+                 (javax.net.ssl SSLContext
+                                SSLParameters)))
+              (let [uri (URI. "https://www.postman-echo.com/get")
+                    req (-> (HttpRequest/newBuilder uri)
+                            (.build))
+                    ssl-context (doto (SSLContext/getInstance "TLS")
+                                  (.init nil nil nil))
+                    client (-> (HttpClient/newBuilder)
+                               (.sslContext ssl-context)
+                               (.build))
+                    res (.send client req (HttpResponse$BodyHandlers/discarding))]
+                (.statusCode res)))))))
+
 (deftest send-async-test
   (is (= 200
          (bb


### PR DESCRIPTION
Sadly, no tests.

hato uses httpkit.server for [testing WebSockets](https://github.com/gnarroway/hato/blob/master/test/hato/websocket_test.clj#L21) , but the implementation in Babashka doesn't include the `org.httpkit.server/with-channel`. Looking at using `as-channel` instead.

I believe this includes all of the implementation classes needed (i.e., `jdk.internal.net.http.websocket.BuilderImpl`), but I haven't confirmed it.