### PR TITLE
Add docs badge to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![project chat](https://img.shields.io/badge/slack-join_chat-brightgreen.svg)](https://app.slack.com/client/T03RZGPFR/CLX41ASCS)
 [![Financial Contributors on Open Collective](https://opencollective.com/babashka/all/badge.svg?label=financial+contributors)](https://opencollective.com/babashka) [![Clojars Project](https://img.shields.io/clojars/v/babashka/babashka.svg)](https://clojars.org/babashka/babashka)
 [![twitter](https://img.shields.io/badge/twitter-%23babashka-blue)](https://twitter.com/search?q=%23babashka&src=typed_query&f=live)
+[![docs](https://img.shields.io/badge/website-docs-blue)](https://book.babashka.org)
 
 <blockquote class="twitter-tweet" data-lang="en">
     <p lang="en" dir="ltr">Life's too short to remember how to write Bash code. I feel liberated.</p>


### PR DESCRIPTION
Finding myself scrolling around the readme for some seconds trying to find the link to the docs, which is a couple of sections down from the top. In order to help people (and myself) to find the reference faster, I added a badge in the top that links to the book/docs.