### PR TITLE
XML edn reading and populating *data-readers* for feature deps

### DIFF
--- a/src/babashka/impl/clojure/core.clj
+++ b/src/babashka/impl/clojure/core.clj
@@ -26,7 +26,7 @@
   ([sym] (core-dynamic-var sym nil))
   ([sym init-val] (sci/new-dynamic-var sym init-val {:ns clojure-core-ns})))
 
-(def data-readers (core-dynamic-var '*data-readers*))
+(def data-readers (core-dynamic-var '*data-readers* {}))
 (def command-line-args (core-dynamic-var '*command-line-args*))
 (def warn-on-reflection (core-dynamic-var '*warn-on-reflection* false))
 (def math-context (core-dynamic-var '*math-context*))

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -430,6 +430,9 @@ Use bb run --help to show this help output.
                    (assoc 'xml/ns @(resolve 'clojure.data.xml.name/uri-symbol)
                           'xml/element @(resolve 'clojure.data.xml.node/tagged-element))))
 
+;; also put the edn readers into *data-readers*
+(sci/alter-var-root core/data-readers into edn-readers)
+
 (defn edn-seq*
   [^java.io.BufferedReader rdr]
   (let [edn-val (edn/read {:eof ::EOF :readers edn-readers :default tagged-literal} rdr)]
@@ -661,7 +664,7 @@ Use bb run --help to show this help output.
 (defn exec [cli-opts]
   (binding [*unrestricted* true]
     (sci/binding [core/warn-on-reflection @core/warn-on-reflection
-                  core/data-readers (into @core/data-readers edn-readers)
+                  core/data-readers @core/data-readers
                   sci/ns @sci/ns]
       (let [{version-opt :version
              :keys [:shell-in :edn-in :shell-out :edn-out

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -425,7 +425,10 @@ Use bb run --help to show this help output.
 
 (def edn-readers (cond-> {}
                    features/yaml?
-                   (assoc 'ordered/map @(resolve 'flatland.ordered.map/ordered-map))))
+                   (assoc 'ordered/map @(resolve 'flatland.ordered.map/ordered-map))
+                   features/xml?
+                   (assoc 'xml/ns @(resolve 'clojure.data.xml.name/uri-symbol)
+                          'xml/element @(resolve 'clojure.data.xml.node/tagged-element))))
 
 (defn edn-seq*
   [^java.io.BufferedReader rdr]
@@ -658,7 +661,7 @@ Use bb run --help to show this help output.
 (defn exec [cli-opts]
   (binding [*unrestricted* true]
     (sci/binding [core/warn-on-reflection @core/warn-on-reflection
-                  core/data-readers @core/data-readers
+                  core/data-readers (into @core/data-readers edn-readers)
                   sci/ns @sci/ns]
       (let [{version-opt :version
              :keys [:shell-in :edn-in :shell-out :edn-out

--- a/test/babashka/xml_test.clj
+++ b/test/babashka/xml_test.clj
@@ -6,8 +6,7 @@
 (def simple-xml-str "<a><b>data</b></a>")
 
 (deftest xml-edn-read-test
-  (let [quoted-xml     (pr-str simple-xml-str)
-        parsed-edn     (test-utils/bb nil (str "(xml/parse-str " quoted-xml ")"))
+  (let [parsed-edn     (test-utils/bb nil (str "(xml/parse-str \"" simple-xml-str "\")"))
         emitted-xml    (test-utils/bb parsed-edn "(xml/emit-str *input*)")]
     (is (str/includes? emitted-xml simple-xml-str))))
 

--- a/test/babashka/xml_test.clj
+++ b/test/babashka/xml_test.clj
@@ -1,0 +1,18 @@
+(ns babashka.xml-test
+  (:require [babashka.test-utils :as test-utils]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+(def simple-xml-str "<a><b>data</b></a>")
+
+(deftest xml-edn-read-test
+  (let [quoted-xml     (pr-str simple-xml-str)
+        parsed-edn     (test-utils/bb nil (str "(xml/parse-str " quoted-xml ")"))
+        emitted-xml    (test-utils/bb parsed-edn "(xml/emit-str *input*)")]
+    (is (str/includes? emitted-xml simple-xml-str))))
+
+(def round-trip-prog
+  (str "(xml/emit-str (read-string (pr-str (xml/parse-str \"" simple-xml-str "\"))))"))
+
+(deftest xml-data-readers-test
+  (is (str/includes? (test-utils/bb nil round-trip-prog) simple-xml-str)))

--- a/test/babashka/yaml_test.clj
+++ b/test/babashka/yaml_test.clj
@@ -1,0 +1,18 @@
+(ns babashka.yaml-test
+  (:require [babashka.test-utils :as test-utils]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+(def simple-yaml-str "topic: [point 1, point 2]")
+
+(deftest yaml-edn-read-test
+  (let [parsed-edn   (test-utils/bb nil (str "(yaml/parse-string \"" simple-yaml-str "\")"))
+        emitted-yaml (test-utils/bb parsed-edn "(yaml/generate-string *input*)")]
+    (is (every? #(str/includes? emitted-yaml %) ["topic:" "point 1" "point 2"]))))
+
+(def round-trip-prog
+  (str "(yaml/generate-string (read-string (pr-str (yaml/parse-string \"" simple-yaml-str "\"))))"))
+
+(deftest yaml-data-readers-test
+  (let [emitted-yaml (test-utils/bb nil round-trip-prog)]
+    (is (every? #(str/includes? emitted-yaml %) ["topic:" "point 1" "point 2"]))))


### PR DESCRIPTION
Should close #1004 .

- On Clojure-JVM, `clojure.core/*data-readers*` has an initial value of an empty map. This change facilitates using `into` later on when we populate `*data-readers*` for 'runtime'.
- conditionally add the `clojure.data.xml` data readers to edn-readers
- the value of edn-readers mostly reflects what `*data-readers*` would be when starting Clojure-JVM with the YAML and XML deps, so we dump edn-readers into `*data-readers*` to emulate the handling of data_readers.clj (it's missing `ordered/set`, but I don't think that's needed for the YAML feature).
- add XML and YAML round-trip testing, both between bb invocations (to emulate piping and exercise edn reading to `*input*`) and within one bb process (to exercise `*data-readers*` usage)
