### PR TITLE
Include java.util.stream.BaseStream in classes.

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -294,6 +294,7 @@
           java.util.jar.JarFile
           java.util.jar.JarEntry
           java.util.jar.JarFile$JarFileEntry
+          java.util.stream.BaseStream
           java.util.stream.Stream
           java.util.Random
           java.util.regex.Matcher


### PR DESCRIPTION
java.util.stream.BaseStream was included in public-classes but not classes itself, which prevented it from being imported:

Before

```
./bb -e "(import 'java.util.stream.BaseStream)"
----- Error --------------------------------------------------------------------
Type:     java.lang.Exception
Message:  Unable to resolve classname: java.util.stream.BaseStream
Location: <expr>:1:1

----- Context ------------------------------------------------------------------
1: (import 'java.util.stream.BaseStream)
   ^--- Unable to resolve classname: java.util.stream.BaseStream

----- Stack trace --------------------------------------------------------------
user - <expr>:1:1
```

After:

```
% ./bb -e "(import 'java.util.stream.BaseStream)"
java.util.stream.BaseStream
```

If you'd like tests, I'll look into added one. I'm wondering if there shouldn't be a lint check or something to confirm that all publi-classes are also included in classes, or something along those lines?