### PR TITLE
print ex-data map from error handler only when in debug mode

### DIFF
--- a/src/babashka/impl/error_handler.clj
+++ b/src/babashka/impl/error_handler.clj
@@ -103,7 +103,7 @@
                                 (.. e getClass getName)))
           (when-let [m (.getMessage e)]
             (println (str "Message:  " m)))
-          (when-let [d (ex-data (.getCause e))]
+          (when-let [d (and (:debug opts) (ex-data (.getCause e)))]
             (print (str "Data:     "))
             (prn d))
           (let [{:keys [:file :line :column]} d]

--- a/test/babashka/error_test.clj
+++ b/test/babashka/error_test.clj
@@ -14,14 +14,9 @@
                   l2 (get lines-s2 i)]
               (if (and l1 l2)
                 (is (= l1 l2)
-                    (format "Lines did not match.
-Line: %s
-Left:  %s
-Right: %s"
-                            i (pr-str l1) (pr-str l2)))
-                (is false (format "Out of lines at line: %s.
-Left:  %s
-Right: %s"
+                  (format "Lines did not match.\nLine: %s\nLeft:  %s\nRight: %s"
+                          i (pr-str l1) (pr-str l2)))
+                (is false (format "Out of lines at line: %s.\nLeft:  %s\nRight: %s"
                                   i (pr-str l1) (pr-str l2))))))
           (range max-lines))))
 

--- a/test/babashka/error_test.clj
+++ b/test/babashka/error_test.clj
@@ -14,8 +14,8 @@
                   l2 (get lines-s2 i)]
               (if (and l1 l2)
                 (is (= l1 l2)
-                  (format "Lines did not match.\nLine: %s\nLeft:  %s\nRight: %s"
-                          i (pr-str l1) (pr-str l2)))
+                    (format "Lines did not match.\nLine: %s\nLeft:  %s\nRight: %s"
+                            i (pr-str l1) (pr-str l2)))
                 (is false (format "Out of lines at line: %s.\nLeft:  %s\nRight: %s"
                                   i (pr-str l1) (pr-str l2))))))
           (range max-lines))))


### PR DESCRIPTION
follow-up from #1021 :
My apologies - I did read that note in the original #1015 description, but for whatever reason, I parsed the bit about printing exception data as "similar to the way bb currently only prints the stack trace and what not (the 'Exception' section of the printed output) when in debug mode", as opposed to what you meant (also suppressing the `ex-data` map if we're not in debug).