### PR TITLE
add PGProperty fields (conditionally) to reflection config

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -337,7 +337,8 @@
                    java.io.EOFException]
     :methods [borkdude.graal.LockFix] ;; support for locking
 
-    :fields [clojure.lang.PersistentQueue]
+    :fields [clojure.lang.PersistentQueue
+             ~@(when features/postgresql? '[org.postgresql.PGProperty])]
     ;; this just adds the class without any methods also suitable for private
     ;; classes: add the privage class here and the public class to the normal
     ;; list above and then everything reachable via the public class will be


### PR DESCRIPTION
fixes #1046 

The pg driver appears to use reflection to check annotations on fields. This change will make those fields available.

The executable sizes produced by my build process are a) not in the "reference context" for size and b) not amazingly consistent, but as far as I can tell:
- when postgres flag is false, the executable size with the change is about 1KB larger than without the change
- when postgres flag is true, the executable seems to consistently be smaller by 100KB - 1MB with the change than it is without the change (I don't understand that, but it seems to work out that way on Windows)

Regarding functional testing, I was able to use the postgresql-test class with `BABASHKA_TEST_ENV=native` (with removing the `tu/jvm?` condition) in https://github.com/babashka/babashka/blob/2bb7499fd55fa2b4c2687f14e09891cb2fa45265/test/babashka/postgresql_test.clj#L21
pre-change, this test exhibits a similar behavior to that described in #1046 (throwing a `java.lang.ExceptionInInitializerError`). Post-change, the test passes. I also tested using a postgres container to more directly reproduce the issue described and verify that the issue is resolved by the change.