### PR TITLE
Add javax.crypto classes necessary for calculating hmac shas.

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -204,6 +204,8 @@
                 java.net.http.WebSocket$Builder
                 java.net.http.WebSocket$Listener
                 java.security.cert.X509Certificate
+                javax.crypto.Mac
+                javax.crypto.spec.SecretKeySpec
                 javax.net.ssl.SSLContext
                 javax.net.ssl.SSLParameters
                 javax.net.ssl.TrustManager

--- a/test/babashka/crypto_test.clj
+++ b/test/babashka/crypto_test.clj
@@ -1,0 +1,31 @@
+(ns babashka.crypto-test
+  (:require [babashka.test-utils :as test-utils]
+            [clojure.edn :as edn]
+            [clojure.test :refer [deftest is]])
+  (:import (javax.crypto Mac)
+           (javax.crypto.spec SecretKeySpec)))
+
+(defn bb [& exprs]
+  (edn/read-string (apply test-utils/bb nil (map str exprs))))
+
+(defn hmac-sha-256 [key data]
+  (let [algo "HmacSHA256"
+        mac (Mac/getInstance algo)]
+    (.init mac (SecretKeySpec. key algo))
+    (.doFinal mac (.getBytes data "UTF-8"))))
+
+(deftest hmac-sha-256-test
+  (let [key-s "some-key"
+        data "some-data"
+        expected-sha (String. (hmac-sha-256 (.getBytes key-s) data))]
+    (is (= expected-sha (bb '(do (ns net
+                                   (:import (javax.crypto Mac)
+                                            (javax.crypto.spec SecretKeySpec)))
+                                 (defn hmac-sha-256 [key data]
+                                   (let [algo "HmacSHA256"
+                                         mac (Mac/getInstance algo)]
+                                     (.init mac (SecretKeySpec. key algo))
+                                     (.doFinal mac (.getBytes data "UTF-8"))))
+                                 (let [key-s "some-key"
+                                       data "some-data"]
+                                   (String. (hmac-sha-256 (.getBytes key-s) data)))))))))


### PR DESCRIPTION
Used by was-api:

https://github.com/cognitect-labs/aws-api/blob/master/src/cognitect/aws/util.clj#L96-L100

Perhaps there's an alternative method to do this calculation with what's already in babashka. I haven't looked, and it's not an area I'm familiar with.