### PR TITLE
Feature request to support shell execution of commands without an extension on MS-Windows

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -77,6 +77,7 @@
                     :feature/selmer
                     :feature/logging
                     {:dependencies [[com.clojure-goes-fast/clj-async-profiler "0.5.0"]
+                                    [com.magnars/test-with-files "2021-02-17"]
                                     [com.opentable.components/otj-pg-embedded "0.13.3"]]}]
              :uberjar {:global-vars {*assert* false}
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"

--- a/test/babashka/impl/tasks_test.clj
+++ b/test/babashka/impl/tasks_test.clj
@@ -1,6 +1,9 @@
 (ns babashka.impl.tasks-test
   (:require [babashka.impl.tasks :as sut]
-            [clojure.test :as t]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :as t]
+            [test-with-files.tools :refer [with-tmp-dir]]))
 
 (t/deftest target-order-test
   (t/is (= '[quux bar foo]
@@ -23,3 +26,91 @@
    :task (clojure \"-M:test -m kaocha.runner\")}
   }}"]
     (t/is (= '[repl watch-tests] (sut/key-order edn)))))
+
+(t/deftest shell
+  (t/testing "command"
+    ;; The hostname tool is ubiquitous
+    (let [process (sut/shell "hostname")]
+      (t/is (= 0 (:exit process)))))
+
+  (when sut/windows?
+    ;; chcp.com is shipped with all MS-Windows versions.
+    (t/testing "MS-Windows .com"
+      (let [process (sut/shell "chcp")]
+        (t/is (= 0 (:exit process)))))
+    )
+  )
+
+(t/deftest windows-add-extension
+  (when sut/windows?
+    (with-tmp-dir tmp-dir
+      ;; create test temp layout
+      ;; tmp-dir
+      ;;       |- a/x.bat
+      ;;       |- b/x.cmd
+      (let [t-a (.getAbsolutePath (io/file tmp-dir "a"))
+            t-b (.getAbsolutePath (io/file tmp-dir "b"))
+            t-a-x-bat (.getAbsolutePath (io/file t-a "x.bat"))
+            t-b-x-cmd (.getAbsolutePath (io/file t-b "x.cmd"))
+            t-a-x (.getAbsolutePath (io/file t-a "x"))
+            p-ta-tb (str/join ";" [t-a t-b])
+            p-tb-ta (str/join ";" [t-b t-a])]
+        (doseq [p [t-a-x-bat t-b-x-cmd]]
+          (io/make-parents p)
+          (spit p nil))
+
+        (t/testing "absolute"
+          (t/is (= t-a-x-bat
+                   (sut/ext-add-windows t-a-x-bat "" "")))
+
+          ;; found via PATHEXT
+          (t/is (= t-a-x-bat
+                   (sut/ext-add-windows t-a-x "" ".bat")))
+          ;; not found, in PATH but not in PATHEXT
+          (t/is (= t-a-x
+                   (sut/ext-add-windows t-a-x "" ".cmd"))))
+
+        (t/testing "current working directory"
+          ;; assuming the babashka repo starts with a lein
+          ;; project. Any other file at the root will do.
+          ;;
+          ;; found via PATHEXT
+          (t/is (= "project.CLJ"
+                   (sut/ext-add-windows "project" "" ".CLJ"))))
+
+        (t/testing "relative"
+          ;; this file.
+          ;;
+          ;; found via PATHEXT
+          (t/is (= "test/babashka/impl/tasks_test.CLJ"
+                   (sut/ext-add-windows "test/babashka/impl/tasks_test" "" ".CLJ"))))
+
+        (t/testing "solo filename"
+          ;; found via PATH
+          (t/is (= "x.bat"
+                   (sut/ext-add-windows "x.bat" t-a "")))
+          ;; not found, no PATHEXT
+          (t/is (= "x"
+                   (sut/ext-add-windows "x" t-a "")))
+          ;; found via PATH
+          (t/is (= "x.BAT"
+                   (sut/ext-add-windows "x" t-a ".BAT")))
+          ;; not found, PATH matches but no matching PATHEXT
+          (t/is (= "x"
+                   (sut/ext-add-windows "x" t-a ".CMD")))
+          ;; found via PATH, PATHEXT
+          (t/is (= "x.CMD"
+                   (sut/ext-add-windows "x" t-b ".CMD")))
+          ;; found via PATHEXT
+          (t/is (= "x.CMD"
+                   (sut/ext-add-windows "x" p-ta-tb ".CMD")))
+          ;; found via first entry in PATH, PATHEXT
+          (t/is (= "x.BAT"
+                   (sut/ext-add-windows "x" p-ta-tb ".BAT;.CMD")))
+          ;; found via first entry in PATH, PATHEXT
+          (t/is (= "x.CMD"
+                   (sut/ext-add-windows "x" p-tb-ta ".BAT;.CMD")))
+          ;; found via first entry in PATH, PATHEXT
+          (t/is (= "x.CMD"
+                   (sut/ext-add-windows "x" p-tb-ta ".CMD;.BAT")))))
+      )))


### PR DESCRIPTION
Hi,

could you please consider patch to enable the tasks `shell` command execute MS-Windows commands without the need to supply an extension, à la the Command Prompt.

Currently, the `shell` cmd can't invoke any commands without supplying an extension, other than those which end in `.exe`.

Other than making the life of the user more difficult having to specify the extension, it affects cross platform compatibility with commands that are available both under the same name on *nix and MS-Windows, but the latter comes with a `.bat` or `.com` extension. Take Clerk's https://github.com/nextjournal/clerk/blob/main/bb.edn task file as an example file that I happen to stumble upon, that calls to `yarn` in`yarn-install`. Yarn is available under `yarn.cmd` on MS-Windows and any attempt to execute it with `shell` with fail with

```
Type:     java.io.IOException
Message:  Cannot run program "yarn": CreateProcess error=2, The system cannot find the file specified
Location: 21:19
```

It works fine if we call `yarn` from the Command Prompt (assuming it is in the PATH).

This means that tools like Clerk, whereby even their dev lifecycle tools are supposed to be cross platform (they are using babashka after all 😎 ), they are not actually no. I don't think it is up to them to correct the `bb.edn` file to check if they running are on MS-Windows so they can call `yarn.cmd` instead of `yarn`. 

As such, please find in the PR a proposal to support invocation of commands by `shell` without supplying an extension, following the same heuristics that Command Prompt is using as described in the `ext-add-windows` fn. 

The patch has all building blocks included, code, comments, tests but please feel free to scrutinize if you think is worth considering the patch. 

There are a couple of areas to be confirmed.

The first is about the `windows?` def, should the corresponding one in `babashka/process.clj` be made public instead? or should it move to a utility namespace?  There doesn't seem to be one.

The second is about the use of the `test-with-files` package that helps with testing a lot of the `ext-add-windows` functionality. Not sure if you mind having another test dependency in. Also that particular test assumes that the current working directory where the tests are invoked is the babashka repo root dir (where `lein test` has been invoked from) so that it can test relative and solo cmd executions. I don't think this is a problem, but just putting it out for being complete.

The `babashka.impl.tasks-test` tests pass on MS-Windows, and all tests pass on Windows.

I've tested the patch with the Clerk's bb tasks and it works.

Thanks!

 