### PR TITLE
Force decimal version numbers in install script

### DIFF
--- a/install
+++ b/install
@@ -91,7 +91,7 @@ esac
 IFS='.' read -ra VER <<< "$version"
 vernum=$(printf "%03d%03d%03d" "${VER[0]}" "${VER[1]}" "${VER[2]}")
 
-if [[ $vernum -le 000002013 ]]; then
+if [[ 10#$vernum -le 10#000002013 ]]; then
   ext="zip"
   util="$(which unzip) -qqo"
 else


### PR DESCRIPTION
Created on behalf of @Cnly

Fixes #1085
