### PR TITLE
Allow building x86_64 or arm64 Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ RUN apt install --no-install-recommends -yy build-essential zlib1g-dev
 WORKDIR "/opt"
 
 ENV GRAALVM_VERSION="21.3.0"
-RUN curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java11-linux-amd64-${GRAALVM_VERSION}.tar.gz
-RUN tar -xzf graalvm-ce-java11-linux-amd64-${GRAALVM_VERSION}.tar.gz
+ARG TARGETARCH
+RUN export ARCH=${TARGETARCH}; if [ "${TARGETARCH}" = "arm64" ]; then ARCH=aarch64; fi && \
+    curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz && \
+    tar -xzf graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz && \
+    rm graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz
 
 ARG BABASHKA_XMX="-J-Xmx4500m"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,17 @@ WORKDIR "/opt"
 
 ENV GRAALVM_VERSION="21.3.0"
 ARG TARGETARCH
-RUN export ARCH=${TARGETARCH}; if [ "${ARCH}" = "" ]; then ARCH=amd64; elif [ "${TARGETARCH}" = "arm64" ]; then ARCH=aarch64; fi && \
-    echo "Building for ${ARCH}" && \
-    curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz && \
-    tar -xzf graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz && \
-    rm graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz
+ENV BABASHKA_ARCH=${TARGETARCH}
+ENV GRAALVM_ARCH=${TARGETARCH}
+RUN if [ "${TARGETARCH}" = "" ] || [ "${TARGETARCH}" = "amd64" ]; then \
+      export GRAALVM_ARCH=amd64; export BABASHKA_ARCH=x86_64; \
+    elif [ "${TARGETARCH}" = "arm64" ]; then \
+      export GRAALVM_ARCH=aarch64; \
+    fi && \
+    echo "Installing GraalVM for ${GRAALVM_ARCH}" && \
+    curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java11-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz && \
+    tar -xzf graalvm-ce-java11-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz && \
+    rm graalvm-ce-java11-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz
 
 ARG BABASHKA_XMX="-J-Xmx4500m"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR "/opt"
 
 ENV GRAALVM_VERSION="21.3.0"
 ARG TARGETARCH
-RUN export ARCH=${TARGETARCH}; if [ "${TARGETARCH}" = "arm64" ]; then ARCH=aarch64; fi && \
+RUN export ARCH=${TARGETARCH}; if [ "${ARCH}" = "" ]; then ARCH=amd64; elif [ "${TARGETARCH}" = "arm64" ]; then ARCH=aarch64; fi && \
+    echo "Building for ${ARCH}" && \
     curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz && \
     tar -xzf graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz && \
     rm graalvm-ce-java11-linux-${ARCH}-${GRAALVM_VERSION}.tar.gz

--- a/script/setup-musl
+++ b/script/setup-musl
@@ -12,7 +12,7 @@ if [[ -z "${BABASHKA_MUSL:-}" ]]; then
     exit 0
 fi
 
-if [[ "${BABASHKA_ARCH}" != "x86_64" ]]; then
+if [[ "${BABASHKA_ARCH:-"x86_64"}" != "x86_64" ]]; then
     echo "GraalVM only supports building static binaries on x86_64."
     exit 1
 fi

--- a/script/setup-musl
+++ b/script/setup-musl
@@ -12,6 +12,11 @@ if [[ -z "${BABASHKA_MUSL:-}" ]]; then
     exit 0
 fi
 
+if [[ "${BABASHKA_ARCH}" != "x86_64" ]]; then
+    echo "GraalVM only supports building static binaries on x86_64."
+    exit 1
+fi
+
 apt-get update -y && apt-get install musl-tools -y
 
 ZLIB_VERSION="1.2.11"


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
Issue:
https://github.com/babashka/babashka/issues/1096

This will now default to building an image for the platform your Docker daemon is running on, but you can override it with the `--platform` arg to `docker buildx build`.

`TARGETARCH` build arg is documented here: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope.

Note that the multi-platform support requires using the [BuildKit backend in Docker](https://github.com/docker/buildx) which should be the default in recent versions of Docker.