### PR TITLE
handle system-specific newlines in a couple of tests

### DIFF
--- a/test-resources/lib_tests/clojure/data/json_test.clj
+++ b/test-resources/lib_tests/clojure/data/json_test.clj
@@ -414,7 +414,7 @@
     (is (= x (json/read-str (with-out-str (json/pprint x)))))))
 
 (deftest pretty-print-nonescaped-unicode
-  (is (= "\"\u1234\u4567\"\n"
+  (is (= (str "\"\u1234\u4567\"" (System/lineSeparator))
          (with-out-str
            (json/pprint "\u1234\u4567" :escape-unicode false)))))
 

--- a/test-resources/lib_tests/table/core_test.clj
+++ b/test-resources/lib_tests/table/core_test.clj
@@ -15,7 +15,7 @@
       +---+---+
       | 3 | 4 |
       +---+---+
-      ") "\n")
+      ") (System/lineSeparator))
     (with-out-str (table [["1" "2"] ["3" "4"]])))))
 
 (deftest test-table-with-vecs-in-vec


### PR DESCRIPTION
This just tweaks the line endings in the test comparisons for a couple of tests, in order to eliminate the Appveyor failures.