### PR TITLE
Fix broken link to source in comment

### DIFF
--- a/examples/http-server.clj
+++ b/examples/http-server.clj
@@ -2,7 +2,7 @@
 #_" -*- mode: clojure; -*-"
 ;; Source: https://gist.github.com/holyjak/36c6284c047ffb7573e8a34399de27d8
 
-;; Based on https://github.com/babashka/babashka/blob/master/examples/image_viewer.clj
+;; Based on https://github.com/babashka/babashka/blob/master/examples/image-viewer.clj
 (ns http-server
   (:require [babashka.fs :as fs]
             [clojure.java.browse :as browse]


### PR DESCRIPTION

Fix a URL in a comment to account for a moved file. None of the following template to-dos appear to be relevant to this one-byte typo fix, but let me know if you disagree:

- [ ] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md). N/A

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). N/A

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions N/A

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue. N/A
