### PR TITLE
Add bill-of-materials to Docker images to aid vulnerability scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- Add metabom jar to docker images [#1133](https://github.com/babashka/babashka/issues/1133)
 ## 0.7.3 (2021-12-30)
 
 - Do not require java for bb tasks without deps [#1123](https://github.com/babashka/babashka/issues/1123), [#1124](https://github.com/babashka/babashka/issues/1124)

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,6 @@ RUN ./script/compile
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -y curl \
         && mkdir -p /usr/local/bin
+COPY --from=BASE /opt/target/metabom.jar /opt/babashka-metabom.jar
 COPY --from=BASE /opt/bb /usr/local/bin/bb
 CMD ["bb"]

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,8 @@
                  [org.clojure/test.check "1.1.0"]
                  [com.github.clj-easy/graal-build-time "0.1.0"]
                  [rewrite-clj/rewrite-clj "1.0.699-alpha"]]
+  :plugins       [[org.kipz/lein-meta-bom "0.1.1"]]
+  :metabom {:jar-name "metabom.jar"}
   :profiles {:feature/xml  {:source-paths ["feature-xml"]
                             :dependencies [[org.clojure/data.xml "0.2.0-alpha6"]]}
              :feature/yaml {:source-paths ["feature-yaml"]

--- a/script/compile
+++ b/script/compile
@@ -33,7 +33,7 @@ rm -rf resources/*.class
 # "$GRAALVM_HOME/bin/javac" -cp "$SVM_JAR" resources/CutOffMisc.java
 if [ -z "$BABASHKA_JAR" ]; then
     lein with-profiles +reflection,+native-image "do" run
-    lein "do" clean, uberjar
+    lein "do" clean, uberjar, metabom
     BABASHKA_JAR=${BABASHKA_JAR:-"target/babashka-$BABASHKA_VERSION-standalone.jar"}
 fi
 

--- a/script/uberjar
+++ b/script/uberjar
@@ -165,5 +165,5 @@ cp deps.edn resources/META-INF/babashka/deps.edn
 
 if [ -z "$BABASHKA_JAR" ]; then
     lein with-profiles "$BABASHKA_LEIN_PROFILES,+reflection,-uberjar" do run
-    lein with-profiles "$BABASHKA_LEIN_PROFILES" do clean, uberjar
+    lein with-profiles "$BABASHKA_LEIN_PROFILES" do clean, uberjar, metabom
 fi


### PR DESCRIPTION
From clojurians slack: https://clojurians.slack.com/archives/CLX41ASCS/p1641396669154300

> I've been playing around with a lein plugin that generates what I'm calling a meta-bom-jar, that basically just contains the group, artifact and version of all a project's dependencies (https://github.com/kipz/lein-meta-bom). If we included this in the babashka Docker images, we could give vulnerability scanners visibility into the bill of materials in use by uberjars, graal native images and so on. I tried on a fork https://github.com/kipz/babashka/tree/metabom and it seems to work (in that grype can now see all the packages in the babashka images).

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to #1133 

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
