### PR TITLE
Add opencontainers annotations to docker image

### DIFF
--- a/.circleci/script/docker
+++ b/.circleci/script/docker
@@ -6,6 +6,15 @@ image_name="babashka/babashka"
 image_tag=$(cat resources/BABASHKA_VERSION)
 platform=${PLATFORM:-"linux/amd64"}
 latest_tag="latest"
+label_args="--label \"org.opencontainers.image.description=Native, fast starting Clojure interpreter for scripting\" \
+            --label \"org.opencontainers.image.title=Babashka\" \
+            --label \"org.opencontainers.image.created=`date -Iseconds`\" \
+            --label \"org.opencontainers.image.url=${CIRCLE_REPOSITORY_URL}\" \
+            --label \"org.opencontainers.image.documentation=${CIRCLE_REPOSITORY_URL}\" \
+            --label \"org.opencontainers.image.source=${CIRCLE_REPOSITORY_URL}\" \
+            --label \"org.opencontainers.image.revision=${CIRCLE_SHA1}\" \
+            --label \"org.opencontainers.image.ref.name=${CIRCLE_TAG:${CIRCLE_BRANCH}}\" \
+            --label \"org.opencontainers.image.version=${image_tag}\""
 
 if [[ $image_tag =~ SNAPSHOT$ ]]; then
     echo "This is a snapshot version"
@@ -25,10 +34,10 @@ if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
         mkdir -p $p
         tar zxvf "/tmp/release/babashka-${image_tag}-${tarball_platform}.tar.gz" -C $p
     done
-    docker buildx build -t "$image_name:$image_tag" --platform "$platform" --push -f Dockerfile.ci .
+    docker buildx build -t "$image_name:$image_tag" --platform "$platform" "$label_args" --push -f Dockerfile.ci .
     if [[ $snapshot == "false" ]]; then
         echo "Building & pushing $platform Docker image(s) $image_name:$latest_tag"
-        docker buildx build -t "$image_name:$latest_tag" --platform "$platform" --push -f Dockerfile.ci .
+        docker buildx build -t "$image_name:$latest_tag" --platform "$platform" "$label_args" --push -f Dockerfile.ci .
     fi
     for p in "${platforms[@]}"; do
         rm -rf $p
@@ -37,7 +46,7 @@ if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
     # alpine doesn't provide upstream arm64 images yet
     if [[ $platform == "linux-amd64" ]]; then
         tar zxvf  "/tmp/release/babashka-${image_tag}-${platform}-static.tar.gz"
-        docker build -t "$image_name:alpine" -f Dockerfile.alpine .
+        docker build -t "$image_name:alpine" "$label_args" -f Dockerfile.alpine .
         rm -f bb
         docker tag "$image_name:alpine" "$image_name:$image_tag-alpine"
         echo "Pushing image $image_name:$image_tag-alpine"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 For a list of breaking changes, check [here](#breaking-changes).
+## Unreleased
 
+- Add opencontainers annoations to docker image [#1134](https://github.com/babashka/babashka/issues/1134)
 ## 0.7.3 (2021-12-30)
 
 - Do not require java for bb tasks without deps [#1123](https://github.com/babashka/babashka/issues/1123), [#1124](https://github.com/babashka/babashka/issues/1124)


### PR DESCRIPTION
Adds  opencontainers annotations to the docker image via the circle-ci build for traceability as per:

https://github.com/opencontainers/image-spec/blob/main/annotations.md

I was unable to test this fully of course!

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to #1134 
- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
