### PR TITLE
Add bill-of-materials to Docker images to aid vulnerability scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
             VERSION=$(cat resources/BABASHKA_VERSION)
             jar=target/babashka-$VERSION-standalone.jar
             cp $jar /tmp/release
-
             java -jar $jar script/reflection.clj
             reflection="babashka-$VERSION-reflection.json"
             java -jar "$jar" --config .build/bb.edn --deps-root . release-artifact "$jar"
@@ -479,7 +478,7 @@ workflows:
       - docker:
           filters:
             branches:
-              only: 
+              only:
                 - master
           requires:
             - linux

--- a/.circleci/script/docker
+++ b/.circleci/script/docker
@@ -33,6 +33,8 @@ if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
         if [[ $tarball_platform == "linux-arm64" ]]; then tarball_platform="linux-aarch64"; fi
         mkdir -p $p
         tar zxvf "/tmp/release/babashka-${image_tag}-${tarball_platform}.tar.gz" -C $p
+        # this overwrites, but this is to work around having built the uberjar/metabom multiple times
+        cp "/tmp/release/${tarball_platform}-metabom.jar" ./metabom.jar
     done
     docker buildx build -t "$image_name:$image_tag" --platform "$platform" "${label_args[@]}" --push -f Dockerfile.ci .
     if [[ $snapshot == "false" ]]; then

--- a/.circleci/script/release
+++ b/.circleci/script/release
@@ -6,9 +6,7 @@ cp bb /tmp/release
 
 VERSION=$(cat resources/BABASHKA_VERSION)
 
-cd /tmp/release
-mkdir -p /tmp/bb_size
-./bb '(spit "/tmp/bb_size/size" (.length (io/file "bb")))'
+
 
 ## release binary as tar.gz archive
 
@@ -17,6 +15,13 @@ arch=${BABASHKA_ARCH:-amd64}
 if [ "$BABASHKA_STATIC" = "true" ]; then
     arch="$arch-static"
 fi
+
+# because circle won't allow the same file to be saved/restored in the same workspace concurrently
+cp metabom.jar "/tmp/release/$BABASHKA_PLATFORM-$arch-metabom.jar"
+
+cd /tmp/release
+mkdir -p /tmp/bb_size
+./bb '(spit "/tmp/bb_size/size" (.length (io/file "bb")))'
 
 archive="babashka-$VERSION-$BABASHKA_PLATFORM-$arch.tar.gz"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- Add metabom jar to docker images [#1133](https://github.com/babashka/babashka/issues/1133)
 - Add opencontainers annoations to docker image [#1134](https://github.com/babashka/babashka/issues/1134)
 - Fix Alpine Linux Docker images in CI script [#1140](https://github.com/babashka/babashka/issues/1140)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,6 @@ RUN ./script/compile
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -y curl \
         && mkdir -p /usr/local/bin
+COPY --from=BASE /opt/target/metabom.jar /opt/babashka-metabom.jar
 COPY --from=BASE /opt/bb /usr/local/bin/bb
 CMD ["bb"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -24,6 +24,7 @@ RUN apk --no-cache add curl ca-certificates tar && \
     apk add --allow-untrusted /tmp/glibc-2.28-r0.apk
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
+COPY metabom.jar /opt/babashka-metabom.jar
 COPY --from=tester /bin/bb /bin/bb
 
 CMD ["bb"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,6 +7,7 @@ RUN apt-get update \
 ARG TARGETARCH
 ARG TARGETOS
 
+COPY metabom.jar /opt/babashka-metabom.jar
 COPY ${TARGETOS}/${TARGETARCH}/bb /usr/local/bin/bb
 
 RUN chmod +x /usr/local/bin/bb

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,8 @@
                  [org.clojure/test.check "1.1.0"]
                  [com.github.clj-easy/graal-build-time "0.1.0"]
                  [rewrite-clj/rewrite-clj "1.0.699-alpha"]]
+  :plugins       [[org.kipz/lein-meta-bom "0.1.1"]]
+  :metabom {:jar-name "metabom.jar"}
   :profiles {:feature/xml  {:source-paths ["feature-xml"]
                             :dependencies [[org.clojure/data.xml "0.2.0-alpha6"]]}
              :feature/yaml {:source-paths ["feature-yaml"]

--- a/script/compile
+++ b/script/compile
@@ -33,9 +33,12 @@ rm -rf resources/*.class
 # "$GRAALVM_HOME/bin/javac" -cp "$SVM_JAR" resources/CutOffMisc.java
 if [ -z "$BABASHKA_JAR" ]; then
     lein with-profiles +reflection,+native-image "do" run
-    lein "do" clean, uberjar
+    lein "do" clean, uberjar, metabom
     BABASHKA_JAR=${BABASHKA_JAR:-"target/babashka-$BABASHKA_VERSION-standalone.jar"}
 fi
+
+# because script/test cleans target during ci before the jar can we saved
+cp target/metabom.jar .
 
 BABASHKA_BINARY=${BABASHKA_BINARY:-"bb"}
 

--- a/script/uberjar
+++ b/script/uberjar
@@ -165,5 +165,5 @@ cp deps.edn resources/META-INF/babashka/deps.edn
 
 if [ -z "$BABASHKA_JAR" ]; then
     lein with-profiles "$BABASHKA_LEIN_PROFILES,+reflection,-uberjar" do run
-    lein with-profiles "$BABASHKA_LEIN_PROFILES" do clean, uberjar
+    lein with-profiles "$BABASHKA_LEIN_PROFILES" do clean, uberjar, metabom
 fi


### PR DESCRIPTION
Second attempt at https://github.com/babashka/babashka/pull/1135

This tries to add the matabom jar to all 3 docker image builds, but is hard to test without attempting a release on github/circle-ci