### PR TITLE
Fix: alpine docker builds in CI (follow-up)

### DIFF
--- a/.circleci/script/docker
+++ b/.circleci/script/docker
@@ -49,9 +49,8 @@ if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
     docker buildx build -t "$image_name:$image_tag-alpine" --platform=linux/amd64 "${label_args[@]}" --push -f Dockerfile.alpine .
     rm -f bb
     if [[ $snapshot == "false" ]]; then
-        docker tag "$image_name:$image_tag-alpine" "$image_name:alpine"
-        echo "Pushing image $image_name:alpine"
-        docker push "$image_name:alpine"
+        echo "Building & pushing Docker image $image_name:alpine"
+        docker buildx build -t "$image_name:alpine" --platform=linux/amd64 "${label_args[@]}" --push -f Dockerfile.alpine .
     fi
 else
     echo "Not publishing Docker image"

--- a/.circleci/script/docker
+++ b/.circleci/script/docker
@@ -45,12 +45,11 @@ if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
 
     # build alpine image for linux-amd64 only (no upstream arm64 support yet)
     tar zxvf  "/tmp/release/babashka-${image_tag}-linux-amd64-static.tar.gz"
-    docker buildx build -t "$image_name:alpine" --platform=linux/amd64 "${label_args[@]}" -f Dockerfile.alpine .
+    echo "Building & pushing Docker image $image_name:$image_tag-alpine"
+    docker buildx build -t "$image_name:$image_tag-alpine" --platform=linux/amd64 "${label_args[@]}" --push -f Dockerfile.alpine .
     rm -f bb
-    docker tag "$image_name:alpine" "$image_name:$image_tag-alpine"
-    echo "Pushing image $image_name:$image_tag-alpine"
-    docker push "$image_name:$image_tag-alpine"
     if [[ $snapshot == "false" ]]; then
+        docker tag "$image_name:$image_tag-alpine" "$image_name:alpine"
         echo "Pushing image $image_name:alpine"
         docker push "$image_name:alpine"
     fi


### PR DESCRIPTION
Follow up to #1141 that makes alpine tagging and pushing consistent with other variants