### PR TITLE
Allow optional (ignored) -- when using using --main

### DIFF
--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -601,7 +601,9 @@ Use bb run --help to show this help output.
           ("--main", "-m",)
           (let [options (next options)]
             (assoc opts-map :main (first options)
-                   :command-line-args (rest options)))
+                   :command-line-args (if (= "--" (second options))
+                                        (nthrest options 2)
+                                        (rest options))))
           ("--run")
           (parse-run-opts opts-map (next options))
           ("--tasks")

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -59,7 +59,8 @@
     (is (:babashka/version v))
     (is (:feature/xml v)))
   (is (= {:force? true} (parse-opts ["--force"])))
-  (is (= {:main "foo", :command-line-args '("-h")} (parse-opts ["-m" "foo" "-h"]))))
+  (is (= {:main "foo", :command-line-args '("-h")} (parse-opts ["-m" "foo" "-h"])))
+  (is (= {:main "foo", :command-line-args '("-h")} (parse-opts ["-m" "foo" "--" "-h"]))))
 
 (deftest version-test
   (is (= [1 0 0] (main/parse-version "1.0.0-SNAPSHOT")))


### PR DESCRIPTION
Permits previously-accepted behavior broken in 19415f63632d2fe8f668fa82ea91c80d06666292

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

Fixes https://github.com/babashka/babashka/issues/1143

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Nope. Not yet.

The added test for `--` as the next arg is simple and works but likely there's a more elegant/idiomatic solution.