### PR TITLE
Ensure leading zeros are not trimmed for algorithm "SHA-256", so that…

### DIFF
--- a/test/babashka/java_security_test.clj
+++ b/test/babashka/java_security_test.clj
@@ -11,10 +11,12 @@
   (clojure.walk/postwalk-replace {::algo algo}
     '(defn signature [^String s]
        (let [algorithm (java.security.MessageDigest/getInstance ::algo)
-             digest (.digest algorithm (.getBytes s))]
-         (format "%032x" (java.math.BigInteger. 1 digest))))))
+             digest    (.digest algorithm (.getBytes s))
+             size      (get {"SHA-256" 64} ::algo 32)]
+         (format (str "%0" size "x") (java.math.BigInteger. 1 digest))))))
 
 (deftest java-security-test
   (is (= "49f68a5c8493ec2c0bf489821c21fc3b" (bb (list 'do (signature "MD5") '(signature "hi")))))
-  (is (= "c22b5f9178342609428d6f51b2c5af4c0bde6a42" (bb (list 'do (signature "SHA-1") '(signature "hi")))))  
-  (is (= "8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4" (bb (list 'do (signature "SHA-256") '(signature "hi"))))))
+  (is (= "c22b5f9178342609428d6f51b2c5af4c0bde6a42" (bb (list 'do (signature "SHA-1") '(signature "hi")))))
+  (is (= "8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4" (bb (list 'do (signature "SHA-256") '(signature "hi")))))
+  (is (= "035afb1672de25549287fa4f6c108c1269c2a1d2390bf069520a95d1fec25e85" (bb (list 'do (signature "SHA-256") '(signature "654321f5fab07590a9e77e19ac4ccf53c8ab05f232b197432b62f2ec0677651bfc4c04"))))))


### PR DESCRIPTION
… hash string size is always 64.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
