### PR TITLE
add `babashka.config` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
-- [#1204](https://github.com/babashka/babashka/issues/1187) add property `babashka.config` to reflect `bb.edn` location ([@mknoszlig](https://github.com/mknoszlig))
+- [#1204](https://github.com/babashka/babashka/issues/1204) add property `babashka.config` to reflect `bb.edn` location ([@mknoszlig](https://github.com/mknoszlig))
 
 ## 0.7.7 (2022-03-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 A preview of the next release can be installed from
 [babashka-dev-builds](https://github.com/babashka/babashka-dev-builds).
 
+## Unreleased
+
+- [#1204](https://github.com/babashka/babashka/issues/1187) add property `babashka.config` to reflect `bb.edn` location ([@mknoszlig](https://github.com/mknoszlig))
+
 ## 0.7.7 (2022-03-04)
 
 ### New

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -933,6 +933,8 @@ Use bb run --help to show this help output.
         bb-edn-file (or config
                         "bb.edn")
         bb-edn (when (fs/exists? bb-edn-file)
+                 (System/setProperty "babashka.config"
+                                     (.getAbsolutePath (io/file bb-edn-file)))
                  (let [raw-string (slurp bb-edn-file)
                        edn (edn/read-string raw-string)
                        edn (assoc edn

--- a/test-resources/babashka/config_property.clj
+++ b/test-resources/babashka/config_property.clj
@@ -1,0 +1,9 @@
+(ns babashka.config-property
+  (:require [babashka.fs :as fs]))
+
+(def prop (System/getProperty "babashka.config"))
+
+(prn (boolean (seq prop)))
+
+(when prop
+    (prn (fs/exists? (System/getProperty "babashka.config"))))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -603,6 +603,13 @@
   (testing "bb executes the empty expression and doesn't start a REPL"
     (is (working? (test-utils/bb nil "-e" "")))))
 
+(deftest config-property-test
+    (is (= "false\n"
+         (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj")))))
+  (is (= "true\ntrue\n"
+         (test-utils/with-config {:tasks {}}
+           (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj")))))))
+
 (deftest file-property-test
   (is (= "true\nfalse\n"
          (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "file_property1.clj")))))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -604,7 +604,7 @@
     (is (working? (test-utils/bb nil "-e" "")))))
 
 (deftest config-property-test
-    (is (= "false\n"
+  (is (= "false\n"
          (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj")))))
   (is (= "true\ntrue\n"
          (test-utils/with-config {:tasks {}}

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -604,11 +604,11 @@
     (is (working? (test-utils/bb nil "-e" "")))))
 
 (deftest config-property-test
-  (is (= "false\n"
-         (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj")))))
   (is (= "true\ntrue\n"
          (test-utils/with-config {:tasks {}}
-           (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj")))))))
+           (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj"))))))
+  (is (= "false\n"
+         (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj"))))))
 
 (deftest file-property-test
   (is (= "true\nfalse\n"

--- a/test/babashka/test_utils.clj
+++ b/test/babashka/test_utils.clj
@@ -135,5 +135,8 @@
          bb-edn-file# (fs/file temp-dir# "bb.edn")]
      (binding [*print-meta* true]
        (spit bb-edn-file# ~cfg))
-     (binding [*bb-edn-path* (str bb-edn-file#)]
-       ~@body)))
+     (try
+       (binding [*bb-edn-path* (str bb-edn-file#)]
+         ~@body)
+       (finally
+         (System/clearProperty "babashka.config")))))

--- a/test/babashka/test_utils.clj
+++ b/test/babashka/test_utils.clj
@@ -48,6 +48,7 @@
   (reset! cp/cp-state nil)
   (reset! main/env {})
   (vreset! common/bb-edn nil)
+  (System/clearProperty "babashka.config")
   (let [args (cond-> args *bb-edn-path*
                      (->> (list* "--config" *bb-edn-path* "--deps-root" ".")))
         os (java.io.StringWriter.)
@@ -135,8 +136,5 @@
          bb-edn-file# (fs/file temp-dir# "bb.edn")]
      (binding [*print-meta* true]
        (spit bb-edn-file# ~cfg))
-     (try
-       (binding [*bb-edn-path* (str bb-edn-file#)]
-         ~@body)
-       (finally
-         (System/clearProperty "babashka.config")))))
+     (binding [*bb-edn-path* (str bb-edn-file#)]
+       ~@body)))


### PR DESCRIPTION
- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to issue [1204](https://github.com/babashka/babashka/issues/1204).

- [x] This PR contains a test to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

There's something curious going on with the tests: 
```bash
> lein test :only babashka.main-test
[...]
Ran 90 tests containing 202 assertions.
0 failures, 0 errors.
```
when running all tests however:
```bash
> lein test
[...]
lein test :only babashka.main-test/config-property-test

FAIL in (config-property-test) (main_test.clj:607)
expected: (= "false\n" (test-utils/bb nil (.getPath (io/file "test-resources" "babashka" "config_property.clj"))))
  actual: (not (= "false\n" "true\ntrue\n"))
[...]
Ran 189 tests containing 563 assertions.
1 failures, 0 errors.
Tests failed.
```

I've poked at it a little bit, and it appears that the generated bb.edn file from a previous test case gets picked up, changing the behaviour. A smaller repro is to reverse the order of test clauses in `config-property-test`. `test-utils/with-config` looks good, however. i'm not sure where that binding escapes.