### PR TITLE
Add Deflater and DeflaterOutputStream

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -376,7 +376,9 @@
           java.util.function.Supplier
           java.util.zip.Inflater
           java.util.zip.InflaterInputStream
+          java.util.zip.Deflater
           java.util.zip.DeflaterInputStream
+          java.util.zip.DeflaterOutputStream
           java.util.zip.GZIPInputStream
           java.util.zip.GZIPOutputStream
           java.util.zip.ZipInputStream


### PR DESCRIPTION
Deflater allows one to control, for example, the level of compression
used. The DeflaterOutputStream is the parent of GZIPOutputStream
class, and allows raw zlib compressed stream (i.e. no gzip header/footer).

Please answer the following questions and leave the below in as part of your PR.

- [ ] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
