### PR TITLE
Unbump zlib to version 1.2.11

### DIFF
--- a/script/setup-musl
+++ b/script/setup-musl
@@ -20,11 +20,12 @@ fi
 apt-get update -y && apt-get install musl-tools -y
 
 ZLIB_VERSION="1.2.11"
+ZLIB_SHA256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 
-curl -O -sL "https://www.zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
+# stable archive path
+curl -O -sL --fail --show-error "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
 
-echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1 zlib-${ZLIB_VERSION}.tar.gz" |
-    sha256sum --check
+echo "${ZLIB_SHA256} zlib-${ZLIB_VERSION}.tar.gz" | sha256sum --check
 tar xf "zlib-${ZLIB_VERSION}.tar.gz"
 
 arch=${BABASHKA_ARCH:-"x86_64"}


### PR DESCRIPTION
The newer 1.2.12 version is breaking the tests. The older version is not
available in the main download path, however it is still available in
the archive.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
