### PR TITLE
Docs/decl pods link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ A preview of the next release can be installed from
 ### New
 
 - [#863](https://github.com/babashka/babashka/issues/863): allow pods to be declared in `bb.edn` and load them when required
-  - See [updated pod library docs for details](TODO: link)
+  - See [updated pod library docs for details](https://github.com/babashka/pods#in-a-babashka-project)
 
 ### Enhanced
 


### PR DESCRIPTION
Just a follow-up PR for declarative pods to complete a TODO in my previous changelog entry
