### PR TITLE
Add prepare subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 A preview of the next release can be installed from
 [babashka-dev-builds](https://github.com/babashka/babashka-dev-builds).
 
+## unreleased
+
+- Add `prepare` subcommand to download deps & pods and cache pod metadata
+
 ## 0.8.0 (2022-04-04)
 
 ### New

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -115,7 +115,8 @@
      "socket-repl"
      "nrepl-server"
      "describe"
-     "print-deps") true
+     "print-deps"
+     "prepare") true
     false))
 
 (defn print-error [& msgs]
@@ -175,6 +176,7 @@ Packaging:
 
   uberscript <file> [eval-opt]  Collect all required namespaces from the classpath into a single file. Accepts additional eval opts, like `-m`.
   uberjar    <jar>  [eval-opt]  Similar to uberscript but creates jar file.
+  prepare                       Download deps & pods defined in bb.edn and cache their metadata. Only an optimization, this will happen on demand when needed.
 
 In- and output flags (only to be used with -e one-liners):
 
@@ -621,6 +623,10 @@ Use bb run --help to show this help output.
                  :command-line-args (next options))
           ("--print-deps")
           (parse-print-deps-opts opts-map (next options))
+          ("--prepare")
+          (let [options (next options)]
+            (recur (next options)
+                   (assoc opts-map :prepare true)))
           ;; fallback
           (if (and opts-map
                    (some opts-map [:file :jar :socket-repl :expressions :main :run]))
@@ -715,7 +721,7 @@ Use bb run --help to show this help output.
                     :main :uberscript :describe?
                     :jar :uberjar :clojure
                     :doc :run :list-tasks
-                    :print-deps]}
+                    :print-deps :prepare]}
             cli-opts
             _ (when debug (vreset! common/debug true))
             _ (do ;; set properties
@@ -883,6 +889,7 @@ Use bb run --help to show this help output.
                        uberjar [nil 0]
                        list-tasks [(tasks/list-tasks sci-ctx) 0]
                        print-deps [(print-deps/print-deps (:print-deps-format cli-opts)) 0]
+                       prepare [nil 0]
                        uberscript
                        [nil (do (uberscript/uberscript {:ctx sci-ctx
                                                         :expressions expressions})


### PR DESCRIPTION
Downloads deps & pods, caches pod metadata, and then exits

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). - not yet but I'd be happy to write one up

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions - no b/c it doesn't really do anything ;) happy to write one if you think appropriate though

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
