### PR TITLE
Improve error message when regex literal in EDN config (#1041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A preview of the next release can be installed from
 
 ## 0.8.1 (TBD)
 
-- [#1041](https://github.com/babashka/babashka/issues/1041): Improve error message when regex literal in bb.edn
+- [#1041](https://github.com/babashka/babashka/issues/1041): Improve error message when regex literal in EDN config
 
 ## 0.8.0 (2022-04-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 A preview of the next release can be installed from
 [babashka-dev-builds](https://github.com/babashka/babashka-dev-builds).
 
+## 0.8.1 (TBD)
+
+- [#1041](https://github.com/babashka/babashka/issues/1041): Improve error message when regex literal in bb.edn
+
 ## 0.8.0 (2022-04-04)
 
 ### New

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -964,6 +964,13 @@ Use bb run --help to show this help output.
                  (and (= minor-current minor-min)
                       (>= patch-current patch-min)))))))
 
+(defn load-edn [string]
+  (try (edn/read-string string)
+    (catch java.lang.RuntimeException e
+      (if (re-find #"No dispatch macro for: \"" (.getMessage e))
+        (throw (ex-info "Invalid regex literal found in bb.edn, use re-pattern instead" {}))
+        (throw e)))))
+
 (defn main [& args]
   (let [[args global-opts] (parse-global-opts args)
         {:keys [:jar] :as file-opt} (when (some-> args first io/file .isFile)
@@ -977,7 +984,9 @@ Use bb run --help to show this help output.
         bb-edn (when bb-edn-file
                  (System/setProperty "babashka.config" bb-edn-file)
                  (let [raw-string (slurp bb-edn-file)
-                       edn (edn/read-string raw-string)
+                       ;; _ (println "!============")
+                       edn (load-edn raw-string)
+                       ;; _ (println "!!============")
                        edn (assoc edn
                                   :raw raw-string
                                   :file bb-edn-file)

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -968,7 +968,7 @@ Use bb run --help to show this help output.
   (try (edn/read-string string)
     (catch java.lang.RuntimeException e
       (if (re-find #"No dispatch macro for: \"" (.getMessage e))
-        (throw (ex-info "Invalid regex literal found in bb.edn, use re-pattern instead" {}))
+        (throw (ex-info "Invalid regex literal found in EDN config, use re-pattern instead" {}))
         (throw e)))))
 
 (defn main [& args]
@@ -984,9 +984,7 @@ Use bb run --help to show this help output.
         bb-edn (when bb-edn-file
                  (System/setProperty "babashka.config" bb-edn-file)
                  (let [raw-string (slurp bb-edn-file)
-                       ;; _ (println "!============")
                        edn (load-edn raw-string)
-                       ;; _ (println "!!============")
                        edn (assoc edn
                                   :raw raw-string
                                   :file bb-edn-file)

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -200,6 +200,12 @@
       (is (thrown-with-msg?
            Exception #"Cyclic task: b"
            (bb "run" "b")))))
+  (testing "friendly regex literal error handling"
+    (test-utils/with-config
+     "{:tasks {something (clojure.string/split \"1-2\" #\"-\")}}"
+     (is (thrown-with-msg?
+          Exception #"Invalid regex literal"
+          (bb "run" "something")))))
   (testing "doc"
     (test-utils/with-config '{:tasks {b {:doc "Beautiful docstring"}}}
       (let [s (test-utils/bb nil "doc" "b")]


### PR DESCRIPTION
Improves the error message by informing the user that literal regex syntax is not allowed and recommends using re-pattern instead.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
