### PR TITLE
update some SciVar names (metadata-wise) to align with babashka name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A preview of the next release can be installed from
 
 - Add `prepare` subcommand to download deps & pods and cache pod metadata
 - [#1041](https://github.com/babashka/babashka/issues/1041): Improve error message when regex literal in EDN config
+- [#1223](https://github.com/babashka/babashka/issues/1223): Ensure that var metadata (specifically `:name`) aligns with the var's symbol (which in turn ensures that `doc` will print the var's name)
 
 ## 0.8.0 (2022-04-04)
 

--- a/feature-hiccup/babashka/impl/hiccup.clj
+++ b/feature-hiccup/babashka/impl/hiccup.clj
@@ -52,10 +52,10 @@
   util/raw-string)
 
 (def hiccup-namespace
-  {'html (copy-var html-1 hns)})
+  {'html (copy-var html-1 hns {:name 'html})})
 
 (def hiccup2-namespace
-  {'html (copy-var html-2 hns2)})
+  {'html (copy-var html-2 hns2 {:name 'html})})
 
 (def html-mode (copy-var util/*html-mode* uns))
 (def escape-strings? (copy-var util/*escape-strings?* uns))

--- a/feature-httpkit-client/babashka/impl/httpkit_client.clj
+++ b/feature-httpkit-client/babashka/impl/httpkit_client.clj
@@ -76,4 +76,4 @@
 
 (def sni-client-namespace
   {'ssl-configurer (copy-var sni-client/ssl-configurer sns)
-   'default-client (sci/new-var 'sni-client sni-client {:ns sns})})
+   'default-client (sci/new-var 'default-client sni-client {:ns sns})})

--- a/src/babashka/impl/clojure/core/async.clj
+++ b/src/babashka/impl/clojure/core/async.clj
@@ -103,10 +103,10 @@
    'untap-all (copy-var async/untap-all core-async-namespace)
    ;; polyfill
    'go (macrofy 'go thread core-async-namespace)
-   '<! (copy-var async/<!! core-async-namespace)
-   '>! (copy-var async/>!! core-async-namespace)
+   '<! (copy-var async/<!! core-async-namespace {:name '<!})
+   '>! (copy-var async/>!! core-async-namespace {:name '>!})
    'alt! (macrofy 'alt! alt!! core-async-namespace)
-   'alts! (copy-var async/alts!! core-async-namespace)
+   'alts! (copy-var async/alts!! core-async-namespace {:name 'alts!})
    'go-loop (macrofy 'go-loop go-loop core-async-namespace)})
 
 (def async-protocols-ns (vars/->SciNamespace 'clojure.core.async.impl.protocols nil))

--- a/src/babashka/impl/clojure/test.clj
+++ b/src/babashka/impl/clojure/test.clj
@@ -332,7 +332,7 @@
     :added "1.1"}
   report-impl :type)
 
-(def report (sci/copy-var report-impl tns))
+(def report (sci/copy-var report-impl tns {:name 'report}))
 
 (defn do-report
   "Add file and line information to a test result and call report.
@@ -722,7 +722,7 @@
                          :expected nil, :actual e})))
       (do-report {:type :end-test-var, :var v}))))
 
-(def test-var (sci/copy-var test-var-impl tns))
+(def test-var (sci/copy-var test-var-impl tns {:name 'test-var}))
 
 (defn test-vars
   "Groups vars by their namespace and runs test-vars on them with

--- a/src/babashka/impl/deps.clj
+++ b/src/babashka/impl/deps.clj
@@ -101,4 +101,4 @@
    'clojure (sci/copy-var bdeps/clojure dns)
    'merge-deps (sci/copy-var merge-deps dns)
    ;; undocumented
-   'merge-defaults (sci/copy-var merge-default-deps dns)})
+   'merge-defaults (sci/copy-var merge-default-deps dns {:name 'merge-defaults})})

--- a/src/babashka/impl/tasks.clj
+++ b/src/babashka/impl/tasks.clj
@@ -20,7 +20,7 @@
 ;; (def task-name (sci/new-dynamic-var '*-task-name* nil {:ns sci-ns}))
 (def task (sci/new-dynamic-var '*task* nil {:ns sci-ns}))
 (def current-task (sci/new-var 'current-task (fn [] @task) {:ns sci-ns}))
-(def state (sci/new-var 'state (atom {}) {:ns sci-ns}))
+(def state (sci/new-var 'current-state (atom {}) {:ns sci-ns}))
 
 (defn log-info [& strs]
   (let [log-level @log-level]

--- a/test-resources/babashka/check_var_names.bb
+++ b/test-resources/babashka/check_var_names.bb
@@ -1,0 +1,13 @@
+(require '[clojure.string :as str])
+(let [ns-maps  (->> (all-ns)
+                 (map (fn [nmspc] [(ns-name nmspc) (ns-publics nmspc)]))
+                 (into {})) ; a map of { ns-name {symbol var, ...}}
+      ns-maps (update-in ns-maps ['user] #(dissoc % '*input*))] ; *input* is a special case that we'll skip over
+   (->>
+     (for [[ns-nm _] ns-maps
+           [sym vr]  (ns-maps ns-nm)
+           :let [{var-meta-ns :ns, var-meta-name :name} (meta vr)
+                 var-meta-ns-name (some-> var-meta-ns ns-name)]]
+       ; build a seq of maps containing the ns/symbol from the ns and the ns/symbol from the var's metadata
+       {:actual-ns ns-nm :actual-ns-symbol sym :var-meta-ns var-meta-ns-name :var-meta-name var-meta-name})
+     (remove #(and (= (:actual-ns %) (:var-meta-ns %)) (= (:actual-ns-symbol %) (:var-meta-name %))))))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -827,7 +827,7 @@ true")))
 
 (deftest var-names-test
   (testing "for all public vars, ns/symbol from ns map matches metadata"
-    (is (empty? (bb nil "-f" "test-resources/babashka/check_var_names.bb")))))
+    (is (empty? (bb nil (.getPath (io/file "test" "babashka" "scripts" "check_var_names.bb")))))))
 
 ;;;; Scratch
 

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -825,6 +825,10 @@ true")))
   (is (= :f (bb nil "(first (into-array [:f]))")))
   (is (= :f (bb nil "(first (first (into-array [(into-array [:f])])))"))))
 
+(deftest var-names-test
+  (testing "for all public vars, ns/symbol from ns map matches metadata"
+    (is (empty? (bb nil "-f" "test-resources/babashka/check_var_names.bb")))))
+
 ;;;; Scratch
 
 (comment

--- a/test/babashka/scripts/check_var_names.bb
+++ b/test/babashka/scripts/check_var_names.bb
@@ -2,7 +2,7 @@
 (let [ns-maps  (->> (all-ns)
                  (map (fn [nmspc] [(ns-name nmspc) (ns-publics nmspc)]))
                  (into {})) ; a map of { ns-name {symbol var, ...}}
-      ns-maps (update-in ns-maps ['user] #(dissoc % '*input*))] ; *input* is a special case that we'll skip over
+      ns-maps (update ns-maps 'user #(dissoc % '*input*))] ; *input* is a special case that we'll skip over
    (->>
      (for [[ns-nm _] ns-maps
            [sym vr]  (ns-maps ns-nm)
@@ -10,4 +10,5 @@
                  var-meta-ns-name (some-> var-meta-ns ns-name)]]
        ; build a seq of maps containing the ns/symbol from the ns and the ns/symbol from the var's metadata
        {:actual-ns ns-nm :actual-ns-symbol sym :var-meta-ns var-meta-ns-name :var-meta-name var-meta-name})
+     ; and remove the matches
      (remove #(and (= (:actual-ns %) (:var-meta-ns %)) (= (:actual-ns-symbol %) (:var-meta-name %))))))


### PR DESCRIPTION
Closes #1223 (to be clear, most of #1223 was done in https://github.com/babashka/sci/pull/710; this just makes a handful of var names be the "expected" names)

This is primarily just a set of little changes to align the var name metadata for copied vars that have a different target name. Additionally, there's a new test that runs a script that checks `(ns-publics)` namespace name and symbol against the corresponding var's metadata and returns any mismatches (and obviously, the test fails if there are any mismatches). Caveat: that test does skip `*input*` because getting to its metadata is... shall we say, not as straightforward as using ns-publics.

before:
```
>bb "(doc hiccup.core/html)"
-------------------------
hiccup.core/html-1
([options & content])
Macro
  Render Clojure data...
```

after:
```
>bb "(doc hiccup.core/html)"
-------------------------
hiccup.core/html
([options & content])
Macro
  Render Clojure data...
```

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
