### PR TITLE
[#556] Add server-status to org.httpkit.server

### DIFF
--- a/feature-httpkit-server/babashka/impl/httpkit_server.clj
+++ b/feature-httpkit-server/babashka/impl/httpkit_server.clj
@@ -8,6 +8,7 @@
   {:obj sns
    'server-stop!              (copy-var server/server-stop! sns)
    'server-port               (copy-var server/server-port sns)
+   'server-status             (copy-var server/server-status sns)
    'run-server                (copy-var server/run-server sns)
    'sec-websocket-accept      (copy-var server/sec-websocket-accept sns)
    'websocket-handshake-check (copy-var server/websocket-handshake-check sns)


### PR DESCRIPTION
This function has been forgotten to be copied to the namespace, as `server-port` already is. 


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
