### PR TITLE
Improve reify error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A preview of the next release can be installed from
 
 - [#1343](https://github.com/babashka/babashka/issues/1343): Fix postgres feature
 - [#1345](https://github.com/babashka/babashka/issues/1345): add `javax.net.ssl.SSLException` and `java.net.SocketTimeoutException` classes ([@lread](https://github.com/lread))
+- Throw exception on attempt to reify multiple interfaces
+- Allow java.lang.Object reify with empty methods
+
 ## 0.9.161 (2022-07-31)
 
 - Fix `exec`

--- a/reify/src/babashka/impl/reify2.clj
+++ b/reify/src/babashka/impl/reify2.clj
@@ -45,6 +45,22 @@
       (invoke [this a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20] (invoke-fn this a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20))
       (applyTo [this arglist] (apply-fn this arglist)))))
 
+(defn reify-object [m]
+  (let [methods (:methods m)
+        toString-fn (or (get methods 'toString)
+                        (fn [this]
+                          (str
+                           (.getName (.getClass this))
+                           "@"
+                           (Integer/toHexString (.hashCode this)))))]
+    (reify
+      sci.impl.types.IReified
+      (getMethods [_] (:methods m))
+      (getInterfaces [_] (:interfaces m))
+      (getProtocols [_] (:protocols m))
+      java.lang.Object
+      (toString [this] (toString-fn this)))))
+
 (defmacro gen-reify-fn []
   `(fn [~'m]
      (when (> (count (:interfaces ~'m)) 1)
@@ -57,19 +73,12 @@
          (getProtocols [_] (:protocols ~'m)))
        (case (.getName ~(with-meta `(first (:interfaces ~'m))
                           {:tag 'Class}))
-         "java.lang.Object"
-         (reify
-           java.lang.Object
-           (toString [~'this]
-             ((method-or-bust (:methods ~'m) (quote ~'toString)) ~'this))
-           sci.impl.types.IReified
-           (getMethods [_] (:methods ~'m))
-           (getInterfaces [_] (:interfaces ~'m))
-           (getProtocols [_] (:protocols ~'m)))
          ~@(mapcat identity
                    (cons
                     ["clojure.lang.IFn"
-                     `(reify-ifn ~'m)]
+                     `(reify-ifn ~'m)
+                     "java.lang.Object"
+                     `(reify-object ~'m)]
                     (for [i interfaces]
                       (let [in (.getName ^Class i)]
                         [in

--- a/reify/src/babashka/impl/reify2.clj
+++ b/reify/src/babashka/impl/reify2.clj
@@ -47,6 +47,8 @@
 
 (defmacro gen-reify-fn []
   `(fn [~'m]
+     (when (> (count (:interfaces ~'m)) 1)
+       (throw (UnsupportedOperationException. "babashka reify only supports implementing a single interface")))
      (if (empty? (:interfaces ~'m))
        (reify
          sci.impl.types.IReified

--- a/test/babashka/reify_test.clj
+++ b/test/babashka/reify_test.clj
@@ -114,3 +114,12 @@
                    iter (reify java.util.function.Consumer (accept [_ x] (vswap! res conj x))))
                   (= [true :a :b :c] @res))]
     (is (true? (bb nil prog)))))
+
+(deftest reify-multiple-interfaces-test
+  (testing "throws exception"
+    (is (thrown?
+         clojure.lang.ExceptionInfo
+         (bb nil "
+(reify
+  java.lang.Object (toString [_] \"foo\")
+  clojure.lang.Seqable (seq [_] '(1 2 3)))")))))

--- a/test/babashka/reify_test.clj
+++ b/test/babashka/reify_test.clj
@@ -51,6 +51,11 @@
 ]")))))
 
 (deftest reify-object
+  (testing "empty methods"
+    (is (clojure.string/starts-with?
+         (bb nil "
+(str (reify Object))")
+         "babashka.impl.reify")))
   (testing "toString"
     (is (= ":foo"
            (bb nil "


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

I thought while I was in the code I would add these improvements.

## Support empty method list on Object reify like clojure

clojure:
```
Clojure 1.10.1
user=> (reify Object)
#object[user$eval136$reify__137 0x35c09b94 "user$eval136$reify__137@35c09b94"]
```

current babashka:
```
user=> (reify Object)
java.lang.ClassCastException: clojure.lang.Symbol cannot be cast to java.lang.Throwable [at <repl>:1:1]
```

this PR:
```
user=> (reify Object)
#object[babashka.impl.reify2$reify_object$reify__27472 0x50e017f0 "babashka.impl.reify2$reify_object$reify__27472@50e017f0"]
```

## Raise exception when user attempts to reify multiple interfaces

current babashka (silent reification of only one interface and inconsitent too. Sometimes first. Sometimes another)
```
user=> (reify java.lang.Object (toString [_] "foo") clojure.lang.Seqable (seq [_] '(1 2 3)))
#object[babashka.impl.clojure.lang.Seqable 0x3ac497ed "babashka.impl.clojure.lang.Seqable@3ac497ed"]
```

this PR
```
user=> (reify java.lang.Object (toString [_] "foo") clojure.lang.Seqable (seq [_] '(1 2 3)))
java.lang.UnsupportedOperationException: babashka reify only supports implementing a single interface [at <repl>:3:1]
```

## Tests

```
$ lein test :only babashka.reify-test/reify-multiple-interfaces-test babashka.reify-test/reify-object
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
==== Testing JVM version

lein test babashka.reify-test
=== reify-object

=== reify-multiple-interfaces-test



Ran 2 tests containing 5 assertions.
0 failures, 0 errors.
```

## Notes

The babashka code raises `java.lang.UnsupportedOperationException`, but that gets turned into `clojure.lang.ExceptionInfo` somewhere along the line. I assume this is as intended.

Feel free to criticise, change, ask, complain, accept or reject.