### PR TITLE
auspex compatibility

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
          "resources" "sci/resources"],
  :deps {org.clojure/clojure {:mvn/version "1.11.1"},
         org.babashka/sci {:local/root "sci"}
-        org.babashka/babashka.impl.reify {:mvn/version "0.1.1"}
+        org.babashka/babashka.impl.reify {:mvn/version "0.1.2"}
         org.babashka/sci.impl.types {:mvn/version "0.0.2"}
         babashka/babashka.curl {:local/root "babashka.curl"}
         babashka/fs {:local/root "fs"}

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [nrepl/bencode "1.1.0"]
                  [borkdude/sci.impl.reflector "0.0.1"]
                  [org.babashka/sci.impl.types "0.0.2"]
-                 [org.babashka/babashka.impl.reify "0.1.1"]
+                 [org.babashka/babashka.impl.reify "0.1.2"]
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/test.check "1.1.1"]
                  [com.github.clj-easy/graal-build-time "0.1.0"]

--- a/reify/build.clj
+++ b/reify/build.clj
@@ -3,7 +3,7 @@
             [clojure.tools.build.api :as b]))
 
 (def lib 'org.babashka/babashka.impl.reify)
-(def version "0.1.1")
+(def version "0.1.2")
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))

--- a/reify/src/babashka/impl/reify2/interfaces.clj
+++ b/reify/src/babashka/impl/reify2/interfaces.clj
@@ -22,7 +22,9 @@
                  java.net.http.WebSocket$Listener
                  java.util.Iterator
                  java.util.function.Consumer
+                 java.util.function.BiConsumer
                  java.util.function.Function
+                 java.util.function.BiFunction
                  java.util.function.Predicate
                  java.util.function.Supplier
                  java.lang.Comparable

--- a/resources/META-INF/babashka/deps.edn
+++ b/resources/META-INF/babashka/deps.edn
@@ -19,7 +19,7 @@
          "resources" "sci/resources"],
  :deps {org.clojure/clojure {:mvn/version "1.11.1"},
         org.babashka/sci {:local/root "sci"}
-        org.babashka/babashka.impl.reify {:mvn/version "0.1.1"}
+        org.babashka/babashka.impl.reify {:mvn/version "0.1.2"}
         org.babashka/sci.impl.types {:mvn/version "0.0.2"}
         babashka/babashka.curl {:local/root "babashka.curl"}
         babashka/fs {:local/root "fs"}

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -115,6 +115,9 @@
     clojure.lang.Ratio
     {:fields [{:name "numerator"}
               {:name "denominator"}]}
+    clojure.lang.Agent
+    {:fields [{:name "pooledExecutor"}
+              {:name "soloExecutor"}]}
     java.util.Iterator
     {:methods [{:name "hasNext"}
                {:name "next"}]}
@@ -459,7 +462,6 @@
     ;; list above and then everything reachable via the public class will be
     ;; visible in the native image.
     :instance-checks [clojure.lang.AFn
-                      clojure.lang.Agent
                       clojure.lang.AFunction
                       clojure.lang.AMapEntry ;; for proxy
                       clojure.lang.APersistentMap ;; for proxy

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -363,7 +363,10 @@
                 java.time.temporal.TemporalAccessor
                 java.time.temporal.TemporalAdjuster])
           java.util.concurrent.atomic.AtomicReference
+          java.util.concurrent.CancellationException
+          java.util.concurrent.CompletionException
           java.util.concurrent.ExecutionException
+          java.util.concurrent.Executor
           java.util.concurrent.LinkedBlockingQueue
           java.util.concurrent.ScheduledThreadPoolExecutor
           java.util.concurrent.ThreadPoolExecutor
@@ -409,6 +412,8 @@
           java.util.UUID
           java.util.function.Consumer
           java.util.function.Function
+          java.util.function.BiConsumer
+          java.util.function.BiFunction
           java.util.function.Predicate
           java.util.function.Supplier
           java.util.zip.Inflater


### PR DESCRIPTION
See https://github.com/mpenet/auspex

```
$ bb -cp $(cat .classpath):test -e "(require '[qbits.auspex-test]) (clojure.test/run-tests 'qbits.auspex-test)"

Testing qbits.auspex-test

Ran 11 tests containing 74 assertions.
0 failures, 0 errors.
{:test 11, :pass 74, :fail 0, :error 0, :type :summary}
``` 