### PR TITLE
Add ThreadPoolExecutor rejection policy classes

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -375,6 +375,10 @@
           java.util.concurrent.LinkedBlockingQueue
           java.util.concurrent.ScheduledThreadPoolExecutor
           java.util.concurrent.ThreadPoolExecutor
+          java.util.concurrent.ThreadPoolExecutor$AbortPolicy
+          java.util.concurrent.ThreadPoolExecutor$CallerRunsPolicy
+          java.util.concurrent.ThreadPoolExecutor$DiscardOldestPolicy
+          java.util.concurrent.ThreadPoolExecutor$DiscardPolicy
           java.util.concurrent.ScheduledExecutorService
           java.util.concurrent.Future
           java.util.concurrent.FutureTask


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR doesn't contain a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions — we'd need to have a test for `ThreadPoolExecutor` first.

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

I'm not sure what kinds of considerations there are related to adding support for classes, but the implementations of these classes is very small, and I think it makes sense to support them since `ThreadPoolExecutor` is already supported.