### PR TITLE
Add more reflection class methods

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -81,6 +81,8 @@
     {:methods [{:name "canAccess"}]}
     java.lang.Package
     {:methods [{:name "getName"}]}
+    java.lang.reflect.Member
+    {:methods [{:name "getModifiers"}]}
     java.lang.reflect.Method
     {:methods [{:name "getName"}
                {:name "getModifiers"}
@@ -89,7 +91,8 @@
     java.lang.reflect.Modifier
     {:methods [{:name "isStatic"}]}
     java.lang.reflect.Field
-    {:methods [{:name "getName"}]}
+    {:methods [{:name "getName"}
+               {:name "getModifiers"}]}
     java.lang.reflect.Array
     {:methods [{:name "newInstance"}
                {:name "set"}]}


### PR DESCRIPTION
Didn't quite catch all of them the first time around. :)

Adding these doesn't seem to have any appreciable effect on the binary size, either:

```bash
λ ls -lat bb
-rwxr-xr-x  1 eerohe  staff  72574720 Sep  9 21:38 bb*
```

(These are necessary for implementing auto-completion for Java class methods.)