### PR TITLE
Add and expose babashka.classes/all-classes

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -5,6 +5,7 @@
    [babashka.impl.proxy :as proxy]
    [cheshire.core :as json]
    [clojure.core.async]
+   [sci.core :as sci]
    [sci.impl.types :as t]))
 
 (def base-custom-map
@@ -744,18 +745,25 @@
        (sort-by :name)
        (vec)))
 
-(defn all-methods []
+(defn all-classes []
+  "Returns every java.lang.Class instance Babashka supports."
   (->> (reflection-file-entries)
        (map :name)
-       (map #(Class/forName %))
-       (mapcat public-declared-method-names)))
+       (map #(Class/forName %))))
+
+(defn all-methods []
+  (mapcat public-declared-method-names (all-classes)))
+
+(def cns (sci/create-ns 'babashka.classes nil))
+
+(def classes-namespace
+  {:obj cns
+   'all-classes (sci/copy-var all-classes cns)})
 
 (comment
   (public-declared-method-names java.net.URL)
   (public-declared-method-names java.util.Properties)
 
-  (->> (reflection-file-entries)
-       (map :name)
-       (map #(Class/forName %)))
+  (all-classes)
 
   )

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -7,7 +7,7 @@
    [babashka.fs :as fs]
    [babashka.impl.bencode :refer [bencode-namespace]]
    [babashka.impl.cheshire :refer [cheshire-core-namespace]]
-   [babashka.impl.classes :as classes]
+   [babashka.impl.classes :as classes :refer [classes-namespace]]
    [babashka.impl.classpath :as cp :refer [classpath-namespace]]
    [babashka.impl.cli :as cli]
    [babashka.impl.clojure.core :as core :refer [core-extras]]
@@ -379,6 +379,7 @@ Use bb run --help to show this help output.
        'clojure.test t/clojure-test-namespace
        'clojure.math math-namespace
        'babashka.classpath classpath-namespace
+       'babashka.classes classes-namespace
        'clojure.pprint pprint-namespace
        'babashka.curl curl-namespace
        'babashka.fs fs-namespace

--- a/test/babashka/classes_test.clj
+++ b/test/babashka/classes_test.clj
@@ -1,0 +1,11 @@
+(ns babashka.classes-test
+  (:require [babashka.test-utils :as tu]
+            [clojure.edn :as edn]
+            [clojure.test :as t :refer [deftest is testing]]))
+
+(defn bb
+  [& args]
+  (edn/read-string (apply tu/bb nil (map pr-str args))))
+
+(deftest all-classes-test
+  (is (true? (bb '(let [classes (babashka.classes/all-classes)] (and (seq classes) (every? class? classes)))))))


### PR DESCRIPTION
- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code):

   To offer editor auto-completion for the Java classes Babashka supports, we need to expose a list of those classes to users.

   Question: should `all-classes` return a list of `java.lang.Class` instances (as in this PR), or a list of symbols?

- [ ] This PR does not contain a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions.

   Maybe it should? Any thoughts on how you'd like to have this tested? Testing is somewhat complicated by the fact that not all class names (e.g. `[Ljava.time.temporal.TemporalField;`) are read-able.

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
