### PR TITLE
Force as global opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- [#1336](https://github.com/babashka/babashka/issues/1336): tasks subcommand doesn't work with global --force option ([@bobisageek](https://github.com/bobisageek))
 - [#1340](https://github.com/babashka/babashka/issues/1340): `defprotocol` are methods missing `:doc` metadata ([@bobisageek](https://github.com/bobisageek))
 - [#1368](https://github.com/babashka/babashka/issues/1368): `-x`: do not pick up on aliases in `user` ns
 - [#1367](https://github.com/babashka/babashka/issues/1367): Fix line number in clojure.test output ([@retrogradeorbit](https://github.com/retrogradeorbit))

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -552,9 +552,6 @@ Use bb run --help to show this help output.
           ("--verbose") (recur (next options)
                                (assoc opts-map
                                       :verbose? true))
-          ("--force") (recur (next options)
-                             (assoc opts-map
-                                    :force? true))
           ("--describe") (recur (next options)
                                 (assoc opts-map
                                        :describe? true))
@@ -698,6 +695,9 @@ Use bb run --help to show this help output.
 
         ("--init")
         (recur (nnext options) (assoc opts-map :init (second options)))
+
+        ("--force")
+        (recur (next options) (assoc opts-map :force? true))
 
         ("--config")
         (recur (nnext options) (assoc opts-map :config (second options)))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -60,7 +60,12 @@
     (is (:feature/xml v)))
   (is (= {:force? true} (parse-opts ["--force"])))
   (is (= {:main "foo", :command-line-args '("-h")} (parse-opts ["-m" "foo" "-h"])))
-  (is (= {:main "foo", :command-line-args '("-h")} (parse-opts ["-m" "foo" "--" "-h"]))))
+  (is (= {:main "foo", :command-line-args '("-h")} (parse-opts ["-m" "foo" "--" "-h"])))
+  (is (= {:force? true :list-tasks true :command-line-args nil} (parse-opts ["--force" "tasks"])))
+  (is (= {:force? true :run "sometask" :command-line-args nil} (parse-opts ["--force" "run" "sometask"])))
+  (is (= {:force? true :repl true} (parse-opts ["--force" "repl"])))
+  (is (= {:force? true :clojure true :command-line-args '("-M" "-r")} 
+        (parse-opts ["--force" "clojure" "-M" "-r"]))))
 
 (deftest version-test
   (is (= [1 0 0] (main/parse-version "1.0.0-SNAPSHOT")))


### PR DESCRIPTION
Closes #1336 

This change moves `--force` from opt parsing to global opt parsing.

I was initially worried about regressions from removing force as an option, but based on some cursory arg parsing testing on master, it looked like (in addition to the issue reported), `--force` often either doesn't set `:force?`, or causes commands that come after it to be treated as a file name (the reported issue is one case of this).

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to #1336 (https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
