### PR TITLE
check if supplied deps is non-empty

### DIFF
--- a/src/babashka/impl/deps.clj
+++ b/src/babashka/impl/deps.clj
@@ -66,7 +66,7 @@
                      paths)
                    paths)]
        (cp/add-classpath (str/join cp/path-sep paths))))
-   (let [need-deps? (or (:deps deps-map)
+   (let [need-deps? (or (seq (:deps deps-map))
                         (and (:aliases deps-map)
                              aliases))]
      (when need-deps?


### PR DESCRIPTION
this should address the empty map supplied as `:deps` as discussed on this Slack [thread](https://clojurians.slack.com/archives/CLX41ASCS/p1664199604550759)