### PR TITLE
Mark bb.edn load exception

### DIFF
--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -1049,7 +1049,7 @@ Use bb run --help to show this help output.
        (catch java.lang.RuntimeException e
          (if (re-find #"No dispatch macro for: \"" (.getMessage e))
            (throw (ex-info "Invalid regex literal found in EDN config, use re-pattern instead" {}))
-           (do (println "Error during loading bb.edn:")
+           (do (.println *err* "Error during loading bb.edn:")
                (throw e))))))
 
 (defn main [& args]

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -1049,7 +1049,8 @@ Use bb run --help to show this help output.
        (catch java.lang.RuntimeException e
          (if (re-find #"No dispatch macro for: \"" (.getMessage e))
            (throw (ex-info "Invalid regex literal found in EDN config, use re-pattern instead" {}))
-           (throw e)))))
+           (do (println "Error during loading bb.edn:")
+               (throw e))))))
 
 (defn main [& args]
   (let [[args global-opts] (parse-global-opts args)

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -1049,7 +1049,8 @@ Use bb run --help to show this help output.
        (catch java.lang.RuntimeException e
          (if (re-find #"No dispatch macro for: \"" (.getMessage e))
            (throw (ex-info "Invalid regex literal found in EDN config, use re-pattern instead" {}))
-           (do (.println *err* "Error during loading bb.edn:")
+           (do (binding [*out* *err*]
+                 (println "Error during loading bb.edn:"))
                (throw e))))))
 
 (defn main [& args]


### PR DESCRIPTION
This improves the error visibilty when loading a `bb.edn` by marking the it better instead of just the stacktrace which could be confusing.