### PR TITLE
feat: Honor `*print-namespace-maps*` in pprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A preview of the next release can be installed from
 ## Unreleased
 
 - Add single argument read method support to PipedInputStream proxy ([@retrogradeorbit](https://github.com/retrogradeorbit))
+- feat: Honor `*print-namespace-maps*` in pprint ([@ghoseb](https://github.com/ghoseb))
 
 ## 0.10.163 (2022-09-24)
 

--- a/src/babashka/impl/pprint.clj
+++ b/src/babashka/impl/pprint.clj
@@ -97,7 +97,8 @@
              pprint/*print-miser-width* @print-miser-width
              *print-meta* @sci/print-meta
              *print-readably* @sci/print-readably
-             *print-length* @sci/print-length]
+             *print-length* @sci/print-length
+             *print-namespace-maps* @sci/print-namespace-maps]
      (pprint/pprint s writer))))
 
 (defn cl-format

--- a/test/babashka/pprint_test.clj
+++ b/test/babashka/pprint_test.clj
@@ -10,3 +10,13 @@
 (deftest print-length-test
   (is (= "(0 1 2 3 4 5 6 7 8 9 ...)"
          (bb "-e" "(set! *print-length* 10) (clojure.pprint/pprint (range 20))"))))
+
+(deftest print-namespaced-map-test
+  (test/testing
+      "Testing disabling of printing namespace maps..."
+      (is (= "{:a/x 1, :a/y 2, :a/z {:b/x 10, :b/y 20}}"
+            (bb "-e" "(binding [*print-namespace-maps* false] (clojure.pprint/pprint {:a/x 1 :a/y 2 :a/z {:b/x 10 :b/y 20}}))"))))
+  (test/testing
+      "Testing manually enabling printing namespace maps..."
+      (is (= "#:a{:x 1, :y 2, :z #:b{:x 10, :y 20}}"
+             (bb "-e" "(binding [*print-namespace-maps* true] (clojure.pprint/pprint {:a/x 1 :a/y 2 :a/z {:b/x 10 :b/y 20}}))")))))


### PR DESCRIPTION
We can now use the dynamic var `*print-namespace-maps*` to control how maps with namespaced keys are printed using `pprint`.

Fixes: #1381

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
