### PR TITLE
Link pod registry to Pods section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Pods are programs that can be used as a Clojure library by
 babashka. Documentation is available in the [pod library
 repo](https://github.com/babashka/pods).
 
-A list of available pods can be found [here](doc/projects.md#pods).
+A list of available pods can be found in the [pod registry](https://github.com/babashka/pod-registry).
 
 ## Differences with Clojure
 


### PR DESCRIPTION
In the `Pods` section we were pointing to a place with a slightly outdated list of projects. This patch adds the correct link to the pod registry.

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).
