### PR TITLE
add force overwrite flag when installing glibc on alpine (docker)

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@ RUN chmod +x /bin/bb
 
 RUN apk --no-cache add curl ca-certificates tar && \
     curl -Ls https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk > /tmp/glibc-2.28-r0.apk && \
-    apk add --allow-untrusted /tmp/glibc-2.28-r0.apk
+    apk add --allow-untrusted --force-overwrite /tmp/glibc-2.28-r0.apk
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
 # TODO: Run actual native tests when they are ported
@@ -21,7 +21,7 @@ FROM alpine:3
 
 RUN apk --no-cache add curl ca-certificates tar && \
     curl -Ls https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk > /tmp/glibc-2.28-r0.apk && \
-    apk add --allow-untrusted /tmp/glibc-2.28-r0.apk
+    apk add --allow-untrusted --force-overwrite /tmp/glibc-2.28-r0.apk
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
 COPY metabom.jar /opt/babashka-metabom.jar


### PR DESCRIPTION
Alpine 3.16 includes /etc/nsswitch.conf, which glibc install tries to create. This change adds the force-overwrite flag to the glibc install.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
