### PR TITLE
Fix issue with empty tasks names display list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ A preview of the next release can be installed from
 
 [Babashka](https://github.com/babashka/babashka): Native, fast starting Clojure interpreter for scripting
 
+## Unreleased
+
+- [#1430](https://github.com/babashka/babashka/issues/1430): Fix issue with `bb tasks` throwing on empty display tasks list. 
+
 ## 1.0.166 (2022-11-24)
 
 See the [Testing babashka scripts](https://blog.michielborkent.nl/babashka-test-runner.html) blog post for how to run tests with this release.

--- a/src/babashka/impl/tasks.clj
+++ b/src/babashka/impl/tasks.clj
@@ -429,15 +429,22 @@
           (iterate zip/right loc))))
 
 (defn list-tasks
+  "Prints out the task names found in BB-EDN in the original order
+  alongside their documentation as retrieved with SCI-CTX.
+
+  For a task to be listed
+  - its name has to be a symbol but should not start with `-`, and
+  - should not be `:private`."
   [sci-ctx]
-  (let [tasks (:tasks @bb-edn)]
-    (if (seq tasks)
-      (let [raw-edn (:raw @bb-edn)
-            names (key-order raw-edn)
-            names (map str names)
-            names (remove #(str/starts-with? % "-") names)
-            names (remove #(:private (get tasks (symbol %))) names)
-            longest (apply max (map count names))
+  (let [tasks (:tasks @bb-edn)
+        raw-edn (:raw @bb-edn)
+        names (when (seq tasks)
+                (->> (key-order raw-edn)
+                     (map str)
+                     (remove #(str/starts-with? % "-"))
+                     (remove #(:private (get tasks (symbol %))))))]
+    (if (seq names)
+      (let [longest (apply max (map count names))
             fmt (str "%1$-" longest "s")]
         (println "The following tasks are available:")
         (println)

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -307,6 +307,25 @@
   (test-utils/with-config {}
     (let [res (test-utils/bb nil "tasks")]
       (is (str/includes? res "No tasks found."))))
+  (test-utils/with-config '{:tasks {:x 1}}
+    (let [res (test-utils/bb nil "tasks")]
+      (is (str/includes? res "No tasks found."))))
+  (test-utils/with-config '{:tasks {-xyz 5}}
+    (let [res (test-utils/bb nil "tasks")]
+      (is (str/includes? res "No tasks found."))))
+  (test-utils/with-config '{:tasks {xyz {:private true}}}
+    (let [res (test-utils/bb nil "tasks")]
+      (is (str/includes? res "No tasks found."))))
+  (test-utils/with-config '{:tasks {abc 1 xyz 2}}
+    (let [res (test-utils/bb nil "tasks")]
+      (is (= "The following tasks are available:\n\nabc\nxyz\n" res))))
+  (test-utils/with-config '{:tasks {abc 1  xyz {:doc "some text" :tasks 5}
+                                    -xyz 3 qrs {:private true}}}
+    (let [res (test-utils/bb nil "tasks")]
+      (is (= "The following tasks are available:\n\nabc\nxyz some text\n" res))))
+  (test-utils/with-config '{:tasks {xyz 1 abc 2}}
+    (let [res (test-utils/bb nil "tasks")]
+      (is (= "The following tasks are available:\n\nxyz\nabc\n" res))))
   (test-utils/with-config "{:paths [\"test-resources/task_scripts\"]
                             :tasks {:requires ([tasks :as t])
                                     task1

--- a/test/babashka/impl/tasks_test.clj
+++ b/test/babashka/impl/tasks_test.clj
@@ -1,9 +1,6 @@
 (ns babashka.impl.tasks-test
-  (:require  [babashka.impl.common :refer [bb-edn]]
-             [babashka.impl.tasks :as sut]
-             [clojure.string :as str]
-             [clojure.test :as t]
-             [sci.core :as sci]))
+  (:require [babashka.impl.tasks :as sut]
+            [clojure.test :as t]))
 
 (t/deftest target-order-test
   (t/is (= '[quux bar foo]
@@ -11,58 +8,6 @@
             {'foo {:depends ['bar 'quux]}
              'bar {:depends ['quux]}}
             'foo))))
-
-(defmacro with-bb-edn
-  "Helper macro to execute BODY reseting BB-EDN to EDN (including :raw)
-  for the duration of the call."
-  [edn & body]
-  `(let [old# @bb-edn]
-     (try
-       (vreset! bb-edn (assoc ~edn :raw (pr-str ~edn)))
-       ~@body
-       (finally
-         (vreset! bb-edn old#)))))
-
-(t/deftest tasks-list
-  (t/testing "empty tasks list"
-    (let [sci-ctx (sci/init {})]
-      (with-bb-edn {:tasks {}}
-        (t/is (= ["No tasks found."]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      (with-bb-edn {:tasks {}}
-        (t/is (= ["No tasks found."]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      (with-bb-edn {:tasks {:x 1}}
-        (t/is (= ["No tasks found."]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      (with-bb-edn {:tasks {'-xyz 5}}
-        (t/is (= ["No tasks found."]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      (with-bb-edn {:tasks {'xyz {:private true}}}
-        (t/is (= ["No tasks found."]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      ;; sanity check for this test
-      (with-bb-edn {:tasks {'xyz {:private false}}}
-        (t/is (= ["The following tasks are available:" "" "xyz"]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))))
-
-  (t/testing "some tasks"
-    (let [sci-ctx (sci/init {})]
-      (with-bb-edn {:tasks {'abc 1
-                            'xyz 2}}
-        (t/is (= ["The following tasks are available:" "" "abc" "xyz"]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      (with-bb-edn {:tasks {'abc 1
-                            'xyz {:doc "some text"
-                                  :tasks 5}
-                            '-xyz 3
-                            'qrs {:private true}}}
-        (t/is (= ["The following tasks are available:" "" "abc" "xyz some text"]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
-      (with-bb-edn {:tasks {'xyz 2
-                            'abc 2}}
-        (t/is (= ["The following tasks are available:" "" "xyz" "abc"]
-                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx)))))))))
 
 (t/deftest key-order-test
   (let [edn "{:tasks

--- a/test/babashka/impl/tasks_test.clj
+++ b/test/babashka/impl/tasks_test.clj
@@ -1,6 +1,9 @@
 (ns babashka.impl.tasks-test
-  (:require [babashka.impl.tasks :as sut]
-            [clojure.test :as t]))
+  (:require  [babashka.impl.common :refer [bb-edn]]
+             [babashka.impl.tasks :as sut]
+             [clojure.string :as str]
+             [clojure.test :as t]
+             [sci.core :as sci]))
 
 (t/deftest target-order-test
   (t/is (= '[quux bar foo]
@@ -8,6 +11,58 @@
             {'foo {:depends ['bar 'quux]}
              'bar {:depends ['quux]}}
             'foo))))
+
+(defmacro with-bb-edn
+  "Helper macro to execute BODY reseting BB-EDN to EDN (including :raw)
+  for the duration of the call."
+  [edn & body]
+  `(let [old# @bb-edn]
+     (try
+       (vreset! bb-edn (assoc ~edn :raw (pr-str ~edn)))
+       ~@body
+       (finally
+         (vreset! bb-edn old#)))))
+
+(t/deftest tasks-list
+  (t/testing "empty tasks list"
+    (let [sci-ctx (sci/init {})]
+      (with-bb-edn {:tasks {}}
+        (t/is (= ["No tasks found."]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      (with-bb-edn {:tasks {}}
+        (t/is (= ["No tasks found."]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      (with-bb-edn {:tasks {:x 1}}
+        (t/is (= ["No tasks found."]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      (with-bb-edn {:tasks {'-xyz 5}}
+        (t/is (= ["No tasks found."]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      (with-bb-edn {:tasks {'xyz {:private true}}}
+        (t/is (= ["No tasks found."]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      ;; sanity check for this test
+      (with-bb-edn {:tasks {'xyz {:private false}}}
+        (t/is (= ["The following tasks are available:" "" "xyz"]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))))
+
+  (t/testing "some tasks"
+    (let [sci-ctx (sci/init {})]
+      (with-bb-edn {:tasks {'abc 1
+                            'xyz 2}}
+        (t/is (= ["The following tasks are available:" "" "abc" "xyz"]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      (with-bb-edn {:tasks {'abc 1
+                            'xyz {:doc "some text"
+                                  :tasks 5}
+                            '-xyz 3
+                            'qrs {:private true}}}
+        (t/is (= ["The following tasks are available:" "" "abc" "xyz some text"]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx))))))
+      (with-bb-edn {:tasks {'xyz 2
+                            'abc 2}}
+        (t/is (= ["The following tasks are available:" "" "xyz" "abc"]
+                 (str/split-lines  (with-out-str (sut/list-tasks sci-ctx)))))))))
 
 (t/deftest key-order-test
   (let [edn "{:tasks


### PR DESCRIPTION
Hi,

can you please consider patch to fix issue with `bb tasks`ing with an empty tasks display list. Fixes #1430 

The logic now considers the reduced list when printing out the tasks list.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
