### PR TITLE
fix #1280

### DIFF
--- a/src/babashka/impl/repl.clj
+++ b/src/babashka/impl/repl.clj
@@ -63,13 +63,14 @@
                   (eval-form sci-ctx `(apply require (quote ~m/repl-requires)))))
       :read (or read
                 (fn [_request-prompt request-exit]
-                  (let [v (parser/parse-next sci-ctx in)]
-                    (skip-if-eol in)
-                    (if (or (identical? :repl/quit v)
-                            (identical? :repl/exit v)
-                            (identical? parser/eof v))
-                      request-exit
-                      v))))
+                  (if (nil? (r/peek-char in))
+                    request-exit
+                    (let [v (parser/parse-next sci-ctx in)]
+                      (skip-if-eol in)
+                      (if (or (identical? :repl/quit v)
+                              (identical? :repl/exit v))
+                        request-exit
+                        v)))))
       :eval (or eval
                 (fn [expr]
                   (sci/with-bindings {sci/file "<repl>"


### PR DESCRIPTION
the problem is that parser/parse-next waits for an enter before returning an object we can use peek-char to pre-emptively react to any EOF at the start of the line in case of not-start-of-line, parse-next takes over

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code), issue #1280

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
