### PR TITLE
Add more java classes and interfaces to support juxt.tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ A preview of the next release can be installed from
 [Babashka](https://github.com/babashka/babashka): Native, fast starting Clojure interpreter for scripting
 
 ## Unreleased
+- Add more java.time and related classes with the goal of supporting juxt.tick https://github.com/juxt/tick/issues/86
 - [#1000](https://github.com/babashka/babashka/issues/1000): add lib tests for xforms ([@bobisageek](https://github.com/bobisageek))
 - [#1482](https://github.com/babashka/babashka/issues/1482): make loading of libs thread safe
 - [#1487](https://github.com/babashka/babashka/issues/1487): `babashka.tasks/clojure` should be supported without arguments to start a REPL

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -364,6 +364,7 @@
           java.security.Security
           java.sql.Date
           java.text.ParseException
+          java.text.ParsePosition
           ;; adds about 200kb, same functionality provided by java.time:
           java.text.SimpleDateFormat
           ~@(when features/java-time?
@@ -391,6 +392,7 @@
                 java.time.format.DateTimeFormatterBuilder
                 java.time.format.DateTimeParseException
                 java.time.format.DecimalStyle
+                java.time.format.FormatStyle
                 java.time.format.ResolverStyle
                 java.time.format.SignStyle
                 java.time.temporal.ChronoField
@@ -403,7 +405,9 @@
                 java.time.format.TextStyle
                 java.time.temporal.Temporal
                 java.time.temporal.TemporalAccessor
-                java.time.temporal.TemporalAdjuster])
+                java.time.temporal.TemporalAdjuster
+                java.time.temporal.TemporalQuery
+                ~(symbol "[Ljava.time.temporal.TemporalQuery;")])
           java.util.concurrent.atomic.AtomicInteger
           java.util.concurrent.atomic.AtomicLong
           java.util.concurrent.atomic.AtomicReference

--- a/test/babashka/java_time_test.clj
+++ b/test/babashka/java_time_test.clj
@@ -2,6 +2,7 @@
   (:require
    [babashka.test-utils :as test-utils]
    [clojure.edn :as edn]
+   [clojure.string :as str]
    [clojure.test :as test :refer [deftest is]]))
 
 (defn bb [expr]
@@ -17,6 +18,12 @@
          (bb '(.format
                (java.time.LocalDateTime/parse "2019-12-18T16:01:41.485")
                (java.time.format.DateTimeFormatter/ofPattern "dd-MM-yyyy HH:mm:ss")))))
+
+  (let [out (bb '(.format (java.time.LocalDateTime/parse "2019-12-18T16:01:41.485")
+                   (java.time.format.DateTimeFormatter/ofLocalizedDateTime java.time.format.FormatStyle/SHORT)))]
+    (is (and (str/includes? out "12") (str/includes? out "18"))))
+
+
   (is (number? (bb "
 (let [x (java.time.LocalDateTime/parse \"2019-12-18T16:01:41.485\")
       y (java.time.LocalDateTime/now)]


### PR DESCRIPTION
I saw that juxt/tick almost has babashka support and decided to look into getting it working. You left a comment here:
https://github.com/juxt/tick/issues/86#issuecomment-646804841
indicating you would welcome PRs adding missing java.time classes so I didn't create an issue a I thought it was clear from that comment one wasn't needed.

The remaining missing classes are all related to date formatting.

This [fork](https://github.com/dvingo/tick/tree/babashka-update
) of juxt/tick has the tests passing in bb against the version of Babashka build off of the branch for this PR.


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
