### PR TITLE
Prevent uberscript/uberjar overwrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ A preview of the next release can be installed from
 - [#1482](https://github.com/babashka/babashka/issues/1482): make loading of libs thread safe
 - [#1487](https://github.com/babashka/babashka/issues/1487): `babashka.tasks/clojure` should be supported without arguments to start a REPL
 - [#1496](https://github.com/babashka/babashka/issues/1496): Add `set-agent-send-executor!` and `set-agent-send-off-executor!`
+- [#1489](https://github.com/babashka/babashka/issues/1489): Don't overwrite non-empty, non-jar files when writing uberscript/uberjar ([@bobisageek](https://github.com/bobisageek))
 
 ## 1.1.173 (2023-02-04)
 

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -780,6 +780,14 @@ Use bb run --help to show this help output.
       env-os-name-present? (not= env-os-name sys-os-name)
       env-os-arch-present? (not= env-os-arch sys-os-arch))))
 
+(defn file-write-allowed?
+  "For output file of uberscript/uberjar, allow writing of jar files
+   and files that are empty/don't exist."
+  [path]
+  (or (= "jar" (fs/extension path))
+    (not (fs/exists? path))
+    (zero? (fs/size path))))
+
 (def seen-urls (atom nil))
 
 (defn read-data-readers [url]
@@ -1062,12 +1070,15 @@ Use bb run --help to show this help output.
                 1)]
         (flush)
         (when uberscript
-          (let [uberscript-out uberscript]
-            (spit uberscript-out "") ;; reset file
-            (doseq [s (distinct @uberscript-sources)]
-              (spit uberscript-out s :append true))
-            (spit uberscript-out preloads :append true)
-            (spit uberscript-out expression :append true)))
+          (if (file-write-allowed? uberscript)
+            (do
+              (spit uberscript "")                        ;; reset file
+              (doseq [s (distinct @uberscript-sources)]
+                (spit uberscript s :append true))
+              (spit uberscript preloads :append true)
+              (spit uberscript expression :append true))
+            (throw (Exception. (str "Uberscript target file '" uberscript
+                                 "' exists and is not empty. Overwrite prohibited.")))))
         (when uberjar
           (if-let [cp (cp/get-classpath)]
             (let [uber-params {:dest uberjar

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -487,6 +487,14 @@
     (is (empty? (bb nil "--uberscript" (test-utils/escape-file-paths (.getPath tmp-file)) "-e" "(System/exit 1)")))
     (is (= "(System/exit 1)" (slurp tmp-file)))))
 
+(deftest uberscript-overwrite-test
+  (testing "trying to make uberscript overwrite a non-empty, non-jar file fails"
+    (let [tmp-file (java.io.File/createTempFile "uberscript_overwrite" ".clj")]
+      (.deleteOnExit tmp-file)
+      (spit (.getPath tmp-file) "this isn't empty")
+      (is (thrown-with-msg? Exception #"Overwrite prohibited."
+            (test-utils/bb nil "--uberscript" (test-utils/escape-file-paths (.getPath tmp-file)) "-e" "(println 123)"))))))
+
 (deftest unrestricted-access
   (testing "babashka is allowed to mess with built-in vars"
     (is (= {} (bb nil "

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -495,6 +495,35 @@
       (is (thrown-with-msg? Exception #"Overwrite prohibited."
             (test-utils/bb nil "--uberscript" (test-utils/escape-file-paths (.getPath tmp-file)) "-e" "(println 123)"))))))
 
+(deftest throw-on-empty-classpath
+  ;; this test fails the windows native test in CI
+  (when-not main/windows?
+    (testing "throw on empty classpath"
+      (let [tmp-file (java.io.File/createTempFile "uber" ".jar")
+            path     (.getPath tmp-file)]
+        (.deleteOnExit tmp-file)
+        (is (thrown-with-msg?
+              Exception #"classpath"
+              (test-utils/bb nil "uberjar" path "-m" "my.main-main")))))))
+
+(deftest target-file-overwrite-test
+  (test-utils/with-config {:paths ["test-resources/babashka/uberjar/src"]}
+    (testing "trying to make uberjar overwrite a non-empty jar file is allowed"
+      (let [tmp-file (java.io.File/createTempFile "uberjar_overwrite" ".jar")
+            path (.getPath tmp-file)]
+        (.deleteOnExit tmp-file)
+        (spit path "this isn't empty")
+        (test-utils/bb nil "--uberjar" (test-utils/escape-file-paths path) "-m" "my.main-main")
+        ; execute uberjar to confirm that the file is overwritten
+        (is (= "(\"42\")\n" (test-utils/bb nil "--prn" "--jar" (test-utils/escape-file-paths path) "42")))))
+    (testing "trying to make uberjar overwrite a non-empty, non-jar file is not allowed"
+      (let [tmp-file (java.io.File/createTempFile "oops_all_source" ".clj")
+            path (.getPath tmp-file)]
+        (.deleteOnExit tmp-file)
+        (spit path "accidentally a source file")
+        (is (thrown-with-msg? Exception #"Overwrite prohibited."
+              (test-utils/bb nil "--uberjar" (test-utils/escape-file-paths path) "-m" "my.main-main")))))))
+
 (deftest unrestricted-access
   (testing "babashka is allowed to mess with built-in vars"
     (is (= {} (bb nil "

--- a/test/babashka/uberjar_test.clj
+++ b/test/babashka/uberjar_test.clj
@@ -97,7 +97,9 @@
             path (.getPath tmp-file)]
         (.deleteOnExit tmp-file)
         (spit path "this isn't empty")
-        (is (= "" (tu/bb nil "--uberjar" (tu/escape-file-paths path) "-m" "my.main-main")))))
+        (tu/bb nil "--uberjar" (tu/escape-file-paths path) "-m" "my.main-main")
+        ; execute uberjar to confirm that the file is overwritten
+        (is (= "(\"42\")\n" (tu/bb nil "--prn" "--jar" (tu/escape-file-paths path) 42)))))
     (testing "trying to make uberjar overwrite a non-empty, non-jar file is not allowed"
       (let [tmp-file (File/createTempFile "oops_all_source" ".clj")
             path (.getPath tmp-file)]

--- a/test/babashka/uberjar_test.clj
+++ b/test/babashka/uberjar_test.clj
@@ -99,7 +99,7 @@
         (spit path "this isn't empty")
         (tu/bb nil "--uberjar" (tu/escape-file-paths path) "-m" "my.main-main")
         ; execute uberjar to confirm that the file is overwritten
-        (is (= "(\"42\")\n" (tu/bb nil "--prn" "--jar" (tu/escape-file-paths path) 42)))))
+        (is (= "(\"42\")\n" (tu/bb nil "--prn" "--jar" (tu/escape-file-paths path) "42")))))
     (testing "trying to make uberjar overwrite a non-empty, non-jar file is not allowed"
       (let [tmp-file (File/createTempFile "oops_all_source" ".clj")
             path (.getPath tmp-file)]


### PR DESCRIPTION
closes #1489 

Summary of changes:
- `file-write-allowed?` checks that the file is a jar or empty/non-existent
- before writing uberjar or uberscript, check that file write is permitted (for uberjar specifically, I tweaked the classpath check into a cond instead of nesting ifs)
- add tests that check:
  - uberscript doesn't overwrite non-empty target
  - uberjar does overwrite non-empty jar
  - uberjar doesn't overwrite non-empty file other than jar (simulating a source file being specified)

We can definitely change the 'overwrite prohibited' message if there's different wording you'd prefer.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
