### PR TITLE
prevent overwrite of empty uber-* target files

### DIFF
--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -785,8 +785,7 @@ Use bb run --help to show this help output.
    and files that are empty/don't exist."
   [path]
   (or (= "jar" (fs/extension path))
-    (not (fs/exists? path))
-    (zero? (fs/size path))))
+    (not (fs/exists? path))))
 
 (def seen-urls (atom nil))
 

--- a/test-resources/lib_tests/hato/client_test.clj
+++ b/test-resources/lib_tests/hato/client_test.clj
@@ -331,7 +331,7 @@
 
 (deftest ^:integration test-http2
   (testing "can make an http2 request"
-    (let [r (get "https://nghttp2.org/httpbin/get" {:as :json})]
+    (let [r (get "https://httpbin.org/get" {:as :json})]
       (is (= :http-2 (:version r))))))
 
 (deftest custom-middleware

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -484,14 +484,14 @@
 (deftest uberscript-test
   (let [tmp-file (java.io.File/createTempFile "uberscript" ".clj")]
     (.deleteOnExit tmp-file)
+    (.delete tmp-file) ; prevent overwrite failure
     (is (empty? (bb nil "--uberscript" (test-utils/escape-file-paths (.getPath tmp-file)) "-e" "(System/exit 1)")))
     (is (= "(System/exit 1)" (slurp tmp-file)))))
 
 (deftest uberscript-overwrite-test
-  (testing "trying to make uberscript overwrite a non-empty, non-jar file fails"
+  (testing "trying to make uberscript overwrite a non-jar file fails"
     (let [tmp-file (java.io.File/createTempFile "uberscript_overwrite" ".clj")]
       (.deleteOnExit tmp-file)
-      (spit (.getPath tmp-file) "this isn't empty")
       (is (thrown-with-msg? Exception #"Overwrite prohibited."
             (test-utils/bb nil "--uberscript" (test-utils/escape-file-paths (.getPath tmp-file)) "-e" "(println 123)"))))))
 
@@ -516,11 +516,10 @@
         (test-utils/bb nil "--uberjar" (test-utils/escape-file-paths path) "-m" "my.main-main")
         ; execute uberjar to confirm that the file is overwritten
         (is (= "(\"42\")\n" (test-utils/bb nil "--prn" "--jar" (test-utils/escape-file-paths path) "42")))))
-    (testing "trying to make uberjar overwrite a non-empty, non-jar file is not allowed"
+    (testing "trying to make uberjar overwrite a non-jar file is not allowed"
       (let [tmp-file (java.io.File/createTempFile "oops_all_source" ".clj")
             path (.getPath tmp-file)]
         (.deleteOnExit tmp-file)
-        (spit path "accidentally a source file")
         (is (thrown-with-msg? Exception #"Overwrite prohibited."
               (test-utils/bb nil "--uberjar" (test-utils/escape-file-paths path) "-m" "my.main-main")))))))
 


### PR DESCRIPTION
This is just the cleanup coming out of #1503 

- babashka.main: don't overwrite any existing non-jar files (including empty)
- babashka.main-test:
  -  where needed, delete the temp output files that would otherwise prevent overwrite
  - since files no longer to be non-empty, remove the writes
- uberscript-test: delete the temp output files that would otherwise prevent overwrite
- hato.client-test: use httpbin for `test-http2`; httpbin uses http/2, and switching to httpbin aligns with the flakiness check

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
