### PR TITLE
fix(docker): make image smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ A preview of the next release can be installed from
 
 [Babashka](https://github.com/babashka/babashka): Native, fast starting Clojure interpreter for scripting
 
+## Unreleased
+
+- [#1523](https://github.com/babashka/babashka/pull/1523): Reduce the size of the Docker images ([@raszi](https://github.com/raszi))
+
 ## 1.3.176 (2023-03-18)
 
 - Upgrade http-client to 0.1.8, fixes binary file uploads (which messed up the previous release)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN if [ "${TARGETARCH}" = "" ] || [ "${TARGETARCH}" = "amd64" ]; then \
     fi && \
     echo "Installing GraalVM for ${GRAALVM_ARCH}" && \
     curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java19-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz && \
-    tar -xzf graalvm-ce-java19-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz && \
-    rm graalvm-ce-java19-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz
+    tar -xzf graalvm-ce-java19-linux-${GRAALVM_ARCH}-${GRAALVM_VERSION}.tar.gz
 
 ARG BABASHKA_XMX="-J-Xmx4500m"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ RUN ./script/setup-musl
 RUN ./script/compile
 
 FROM ubuntu:latest
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR "/usr/local/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,10 @@ RUN ./script/setup-musl
 RUN ./script/compile
 
 FROM ubuntu:latest
-RUN apt-get update && apt-get install -y curl \
-        && mkdir -p /usr/local/bin
+RUN apt-get update && apt-get install -y curl
+
+WORKDIR "/usr/local/bin"
+
 COPY --from=BASE /opt/target/metabom.jar /opt/babashka-metabom.jar
 COPY --from=BASE /opt/bb /usr/local/bin/bb
 CMD ["bb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,8 @@ RUN ./script/compile
 
 FROM ubuntu:latest
 RUN apt-get update && apt-get install -y curl \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR "/usr/local/bin"
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/local/bin
 
 COPY --from=BASE /opt/target/metabom.jar /opt/babashka-metabom.jar
 COPY --from=BASE /opt/bb /usr/local/bin/bb

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -23,7 +23,7 @@ FROM alpine:3
 
 RUN apk --no-cache add curl ca-certificates tar && \
     curl -Ls https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk > /tmp/glibc-2.28-r0.apk && \
-    apk add --allow-untrusted --force-overwrite /tmp/glibc-2.28-r0.apk
+    apk add --allow-untrusted --force-overwrite /tmp/glibc-2.28-r0.apk && rm /tmp/glibc-2.28-r0.apk
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
 COPY metabom.jar /opt/babashka-metabom.jar

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,9 @@ FROM ubuntu:latest
 
 RUN apt-get update \
     && apt-get install -y curl \
-    && mkdir -p /usr/local/bin
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR "/usr/local/bin"
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,9 +2,8 @@ FROM ubuntu:latest
 
 RUN apt-get update \
     && apt-get install -y curl \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR "/usr/local/bin"
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/local/bin
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
By removing the package list we could reduce the Docker image size even further from 217MB to 174MB.