### PR TITLE
add test for error message for clojure {:dir "missing-directory"}

### DIFF
--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -317,10 +317,10 @@
     #_(test-utils/with-config
         (pr-str '{:tasks {foo (-> (clojure) :out prn)}})
         (is (str/includes? (test-utils/bb "(+ 1 2 3)" "run" "foo") "6"))))
-  (testing "call to run in missing dir includes dir name in output"
+  (testing "call to run in missing dir gives 'cannot run program' message"
     (test-utils/with-config
       (pr-str '{:tasks {foo (clojure {:dir "../missingdir"} "-M" "-r")}})
-      ; check rough text of error message, message about missing directory is OS-dependent
+      ; check rough text of error message, specific message about missing directory is OS-dependent
       (is (thrown-with-msg? Exception #"Cannot run program .* \(in directory \"\.\.[/\\]missingdir\"\)" 
                             (bb "run" "foo"))))))
 

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -316,7 +316,13 @@
     ;; can't properly test this, but `(clojure)` should work with zero args
     #_(test-utils/with-config
         (pr-str '{:tasks {foo (-> (clojure) :out prn)}})
-        (is (str/includes? (test-utils/bb "(+ 1 2 3)" "run" "foo") "6")))))
+        (is (str/includes? (test-utils/bb "(+ 1 2 3)" "run" "foo") "6"))))
+  (testing "call to run in missing dir includes dir name in output"
+    (test-utils/with-config
+      (pr-str '{:tasks {foo (clojure {:dir "../missingdir"} "-M" "-r")}})
+      ; check rough text of error message, message about missing directory is OS-dependent
+      (is (thrown-with-msg? Exception #"Cannot run program .* \(in directory \"\.\.[/\\]missingdir\"\)" 
+                            (bb "run" "foo"))))))
 
 (deftest list-tasks-test
   (test-utils/with-config {}


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.


Could close #1189 - adds a test that checks bits of the error message.

This test checks just the message content coming from the JVM, because the lower-level messages differ between OSes, e.g.
- `CreateProcess error=267, The directory name is invalid` on Windows, vs
- `error=2, No such file or directory`  on my linux machine