### PR TITLE
Support babashka.process reload for exec fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ in the CfP!
 ## Unreleased
 
 - [#1524](https://github.com/babashka/babashka/issues/1524): Remove dynamic builds for linux-aarch64 ([@lispyclouds](https://github.com/lispyclouds))
+- [#1577](https://github.com/babashka/babashka/issues/1557): Add support for `babashka.process/exec` after namespace reload of `babashka.process` ([@lread](https://github.com/lread)) 
 
 ## 1.3.179 (2023-04-26)
 

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -15,6 +15,9 @@
 (def has-domain-sockets?
   (resolve 'java.net.UnixDomainSocketAddress))
 
+(def has-graal-process-properties?
+  (resolve 'org.graalvm.nativeimage.ProcessProperties))
+
 (def base-custom-map
   `{clojure.lang.LineNumberingPushbackReader {:allPublicConstructors true
                                               :allPublicMethods true}
@@ -183,7 +186,8 @@
                             {:methods [{:name "getBundle"
                                         :parameterTypes ["java.lang.String","java.util.Locale",
                                                          "java.lang.ClassLoader"]}]})
-    (resolve 'org.graalvm.nativeimage.ProcessProperties)
+
+    has-graal-process-properties?
     (assoc `org.graalvm.nativeimage.ProcessProperties
            {:methods [{:name "exec"}]})))
 

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -182,7 +182,12 @@
                             `java.util.ResourceBundle
                             {:methods [{:name "getBundle"
                                         :parameterTypes ["java.lang.String","java.util.Locale",
-                                                         "java.lang.ClassLoader"]}]})))
+                                                         "java.lang.ClassLoader"]}]})
+    features/graal? (assoc `org.graalvm.nativeimage.ProcessProperties
+                           {:methods [{:name "exec"
+                                       :parameterTypes ["java.nio.file.Path"
+                                                        "[Ljava.lang.String;"
+                                                        "java.util.Map"]}]})))
 
 (def java-net-http-classes
   "These classes must be initialized at run time since GraalVM 22.1"

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -183,11 +183,9 @@
                             {:methods [{:name "getBundle"
                                         :parameterTypes ["java.lang.String","java.util.Locale",
                                                          "java.lang.ClassLoader"]}]})
-    features/graal? (assoc `org.graalvm.nativeimage.ProcessProperties
-                           {:methods [{:name "exec"
-                                       :parameterTypes ["java.nio.file.Path"
-                                                        "[Ljava.lang.String;"
-                                                        "java.util.Map"]}]})))
+    (resolve 'org.graalvm.nativeimage.ProcessProperties)
+    (assoc `org.graalvm.nativeimage.ProcessProperties
+           {:methods [{:name "exec"}]})))
 
 (def java-net-http-classes
   "These classes must be initialized at run time since GraalVM 22.1"

--- a/src/babashka/impl/features.clj
+++ b/src/babashka/impl/features.clj
@@ -17,6 +17,7 @@
 (def selmer?         (not= "false" (System/getenv "BABASHKA_FEATURE_SELMER")))
 (def logging?        (not= "false" (System/getenv "BABASHKA_FEATURE_LOGGING")))
 (def priority-map?   (not= "false" (System/getenv "BABASHKA_FEATURE_PRIORITY_MAP")))
+(def graal?          (not= "false" (System/getenv "BABASHKA_FEATURE_GRAAL")))
 
 ;; excluded by default
 (def jdbc? (= "true" (System/getenv "BABASHKA_FEATURE_JDBC")))

--- a/src/babashka/impl/features.clj
+++ b/src/babashka/impl/features.clj
@@ -17,7 +17,6 @@
 (def selmer?         (not= "false" (System/getenv "BABASHKA_FEATURE_SELMER")))
 (def logging?        (not= "false" (System/getenv "BABASHKA_FEATURE_LOGGING")))
 (def priority-map?   (not= "false" (System/getenv "BABASHKA_FEATURE_PRIORITY_MAP")))
-(def graal?          (not= "false" (System/getenv "BABASHKA_FEATURE_GRAAL")))
 
 ;; excluded by default
 (def jdbc? (= "true" (System/getenv "BABASHKA_FEATURE_JDBC")))


### PR DESCRIPTION
Exposed GraalVM `ProcessProperties/exec` signature used by babashka.process/exec.

Add new `graal?` feature (on by default) to allow folks to build/use babashka without this specific Graal API.

On my linux dev box bb executable increased by 8kb.

Closes #1557

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
