### PR TITLE
tests: run babashka.process lib tests on windows

### DIFF
--- a/test-resources/lib_tests/babashka/run_all_libtests.clj
+++ b/test-resources/lib_tests/babashka/run_all_libtests.clj
@@ -93,13 +93,13 @@
   (test-doric-cyclic-dep-problem))
 
 ;;;; babashka.process
-(when-not (windows?)
-  ;; test built-in babashka.process
-  (test-namespaces 'babashka.process-test)
+;; test built-in babashka.process
+(test-namespaces 'babashka.process-test)
 
-  ;; test babashka.process from source
-  (require '[babashka.process] :reload)
-  (test-namespaces 'babashka.process-test))
+;; test babashka.process from source
+#_{:clj-kondo/ignore [:duplicate-require]}
+(require '[babashka.process] :reload)
+(test-namespaces 'babashka.process-test)
 
 ;;;; final exit code
 


### PR DESCRIPTION
Now that babashka.process tests are os agnostic we can also run them on Windows.

Retrying #1559 