### PR TITLE
tests: run babashka.process lib tests on windows

### DIFF
--- a/test-resources/lib_tests/babashka/run_all_libtests.clj
+++ b/test-resources/lib_tests/babashka/run_all_libtests.clj
@@ -93,13 +93,13 @@
   (test-doric-cyclic-dep-problem))
 
 ;;;; babashka.process
-(when-not (windows?)
-  ;; test built-in babashka.process
-  (test-namespaces 'babashka.process-test)
+;; test built-in babashka.process
+(test-namespaces 'babashka.process-test)
 
-  ;; test babashka.process from source
-  (require '[babashka.process] :reload)
-  (test-namespaces 'babashka.process-test))
+;; test babashka.process from source
+#_{:clj-kondo/ignore [:duplicate-require]}
+(require '[babashka.process] :reload)
+(test-namespaces 'babashka.process-test)
 
 ;;;; final exit code
 


### PR DESCRIPTION
Now that babashka.process tests are os agnostic we can also run them on Windows.

This should now work, see babashka/process#126

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] @borkdude and I chatted on Slack and agreed a PR without an issue was fine for this one

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
