### PR TITLE
Fix README.md prepending the command with bb

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ File `pst.clj`:
 ```
 
 ``` shell
-$ pst.clj
+$ bb pst.clj
 05:17
 ```
 


### PR DESCRIPTION
Maybe I'm missing something, but I think the `.clj` file cannot be started without `bb` as the command name.

---

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
