### PR TITLE
Bumping selmer version to 1.12.59

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -44,7 +44,7 @@
         org.clojure/core.match {:mvn/version "1.0.0"}
         hiccup/hiccup {:mvn/version "2.0.0-RC1"}
         rewrite-clj/rewrite-clj {:mvn/version "1.1.46"}
-        selmer/selmer {:mvn/version "1.12.50"}
+        selmer/selmer {:mvn/version "1.12.59"}
         com.taoensso/timbre {:mvn/version "6.0.1"}
         org.clojure/tools.logging {:mvn/version "1.1.0"}
         org.clojure/data.priority-map {:mvn/version "1.1.0"}
@@ -67,7 +67,7 @@
            {:extra-paths ["process/src" "process/test" "test-resources/lib_tests"]
             :extra-deps {org.clj-commons/clj-http-lite {:mvn/version "0.4.392"}
                          #_#_org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
-                                                  :sha "0dec1f88cbde74a0470b454396f09a03adb4ae39"}
+                                                      :sha "0dec1f88cbde74a0470b454396f09a03adb4ae39"}
                          lambdaisland/regal {:mvn/version "0.0.143"}
                          cprop/cprop {:mvn/version "0.1.16"}
                          comb/comb {:mvn/version "0.1.1"}

--- a/project.clj
+++ b/project.clj
@@ -72,7 +72,7 @@
              :feature/test-check {:source-paths ["feature-test-check"]}
              :feature/spec-alpha {:source-paths ["feature-spec-alpha"]}
              :feature/selmer {:source-paths ["feature-selmer"]
-                              :dependencies [[selmer/selmer "1.12.50"]]}
+                              :dependencies [[selmer/selmer "1.12.59"]]}
              :feature/logging {:source-paths ["feature-logging"]
                                :dependencies [[com.taoensso/timbre "6.0.4"]
                                               [org.clojure/tools.logging "1.1.0"]]}


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

No, but we discussed it on the slack, I'm simply bumping Selmer version so it has access to the new resolve-arg fn from selmer.parser.

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

No, not sure we need one just for a version bump?

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Wasn't sure where to add it, in the Unreleased section?
