### PR TITLE
Include IvParameterSpec so we can have ansible-vault-clj decryption

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -227,6 +227,7 @@
     javax.crypto.SecretKey
     javax.crypto.SecretKeyFactory
     javax.crypto.spec.GCMParameterSpec
+    javax.crypto.spec.IvParameterSpec
     javax.crypto.spec.PBEKeySpec
     javax.crypto.spec.SecretKeySpec
     javax.net.ssl.HostnameVerifier ;; clj-http-lite


### PR DESCRIPTION
Please consider adding this class to bb.

I'm looking to implement ansible-vault decryption in babashka and I need the above class. 
Decryption works in Clojure but fails with missing class for babashka. 

After this I need to fix crypto padding and all is good :). 

https://docs.ansible.com/ansible/latest/vault_guide/vault_using_encrypted_content.html#format-of-files-encrypted-with-ansible-vault .

(I've read the lines bellow and I'll think of a test for this tomorrow). 

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
