### PR TITLE
Update clojure example to new calling convention

### DIFF
--- a/src/babashka/deps.clj
+++ b/src/babashka/deps.clj
@@ -22,7 +22,7 @@
 
   Examples:
 
-  (-> (clojure '[-M -e (+ 1 2 3)] {:out :string}) deref :out) returns
+  (-> (clojure {:out :string} '-M '-e '(+ 1 2 3)]) deref :out) returns
   \"6\n\".
 
   (-> @(clojure) :exit) starts a clojure REPL, waits for it


### PR DESCRIPTION
Per [Slack](https://clojurians.slack.com/archives/CLX41ASCS/p1707224925015389?thread_ts=1707224870.345309&cid=CLX41ASCS):
> The official way of calling `clojure` is now:
> `(clojure {opts} ..args)`

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
   - can do if needed, but the problem statement is at the top of this PR

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
  - doc update only

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
  - will do