### PR TITLE
Suggest using mise instead of asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,24 @@ linux binary.
 
 ### asdf
 
-[asdf](https://github.com/asdf-vm/asdf) is an extendable version manager for linux and macOS.
+[asdf](https://github.com/asdf-vm/asdf) is an extendable version manager for linux and macOS. Note that asdf will add significant startup time to any babashka script, consider using [mise](#mise) instead.
 
 Babashka can be installed using a plugin as follows:
 
     asdf plugin add babashka https://github.com/pitch-io/asdf-babashka
     asdf install babashka latest
+
+### mise
+
+[mise](https://mise.jdx.dev/) is a development environment setup tool for linux and macOS.
+
+Install:
+
+    mise use --global babashka@latest
+
+Upgrade:
+
+    mise upgrade babashka
 
 ### Windows
 


### PR DESCRIPTION
This PR adds note on asdf performance, suggests mise instead, and adds mise installation instructions.

It seems like a shame when so much work has been put into getting bb to start in 20 ms that asdf adds 120-150 ms. And this is not obvious behavior, new bb users will probably just draw the conclusion that bb is very slow to startup instead of suspecting the real culprit, so I think documenting this is warranted.

Sources, the first is from asdf maintainer stating 150 ms for exec, the latter is mise stating 120 ms:

https://stratus3d.com/blog/2022/08/11/asdf-performance/

https://mise.jdx.dev/dev-tools/comparison-to-asdf.html#performance