### PR TITLE
make CLI args available to REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ A preview of the next release can be installed from
 - Fix [#1688](https://github.com/babashka/babashka/issues/1688): use-fixtures should add metadata to `*ns*`
 - Fix [#1692](https://github.com/babashka/babashka/issues/1692): Add support for ITransientSet and org.flatland/ordered-set
 - Bump org.flatland/ordered to `1.15.12`.
+- Partially Fix [#1695](https://github.com/babashka/babashka/issues/1695): `--repl` arg handling should consume only one arg (itself) ([@bobisageek](https://github.com/bobisageek))
+- Partially Fix [#1695](https://github.com/babashka/babashka/issues/1695): make `*command-line-args*` value available in the REPL ([@bobisageek](https://github.com/bobisageek))
 
 ## 1.3.190 (2024-04-17)
 

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -1021,7 +1021,8 @@ Use bb run --help to show this help output.
                        doc (print-doc sci-ctx command-line-args)
                        describe?
                        [(print-describe) 0]
-                       repl [(repl/start-repl! sci-ctx) 0]
+                       repl (sci/binding [core/command-line-args command-line-args] 
+                              [(repl/start-repl! sci-ctx) 0])
                        nrepl [(start-nrepl! nrepl) 0]
                        uberjar [nil 0]
                        list-tasks [(tasks/list-tasks sci-ctx) 0]
@@ -1069,7 +1070,8 @@ Use bb run --help to show this help output.
                        clojure [nil (if-let [proc (bdeps/clojure command-line-args)]
                                       (-> @proc :exit)
                                       0)]
-                       :else [(repl/start-repl! sci-ctx) 0]))
+                       :else (sci/binding [core/command-line-args command-line-args]
+                               [(repl/start-repl! sci-ctx) 0])))
                 1)]
         (flush)
         (when uberscript

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -613,7 +613,7 @@ Use bb run --help to show this help output.
                           :uberjar (first options))))
           ("--repl")
           (let [options (next options)]
-            (recur (next options)
+            (recur options
                    (assoc opts-map
                           :repl true)))
           ("--socket-repl")

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -480,7 +480,11 @@
 
 (deftest command-line-args-test
   (is (true? (bb nil "(nil? *command-line-args*)")))
-  (is (= ["1" "2" "3"] (bb nil "*command-line-args*" "1" "2" "3"))))
+  (is (= ["1" "2" "3"] (bb nil "*command-line-args*" "1" "2" "3")))
+  (is (str/includes? (test-utils/bb "*command-line-args*" "repl" "--" "1" "2" "3")
+        "(\"1\" \"2\" \"3\""))
+  (is (str/includes? (test-utils/bb "*command-line-args*" "--" "1" "2" "3")
+        "(\"1\" \"2\" \"3\"")))
 
 (deftest constructors-test
   (testing "the clojure.lang.Delay constructor works"

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -68,6 +68,10 @@
   (is (= {:force? true :repl true} (parse-opts ["--force" "repl"])))
   (is (= {:force? true :clojure true :command-line-args '("-M" "-r")}
          (parse-opts ["--force" "clojure" "-M" "-r"])))
+  (is (= {:command-line-args '("asdf" "fdsa")}
+        (main/parse-opts ["--" "asdf" "fdsa"])))
+  (is (= {:repl true :command-line-args '("asdf" "fdsa")}
+        (main/parse-opts ["repl" "--" "asdf" "fdsa"])))
   (testing "file opts parsing does not mess with :command-line-args"
     (is (= {:prn true, :expressions ["(prn :foo)"]}
            (-> (let [[_ opts] (main/parse-file-opt ["-e" "(prn :foo)"] {})]


### PR DESCRIPTION
This change is intended to address a couple of issues described in #1695 

### Change 1 - `--repl` should consume one argument (itself) from the arg list
Scenario 4 from the issue:
```
$ bb repl -- asdf sdf <<< '*command-line-args*'
----- Error --------------------------------------------------------------------
Type:     java.lang.Exception
Message:  File does not exist: asdf
```

**Problem Statement**
`--` does not cause args to stop being processed as bb arguments if it comes after `repl` or `--repl` in the arg list
**Root Cause**
`--repl` consumes two arguments from the arg list
**Fix**
main.clj, line 616: recur with `options` (which has already had `--repl` removed)
**Tests**
Added a test for this combination of args

### Change 2 - make `*command-line-args*` available to REPL
Scenario 3 from the issue:
```
$ bb -- asdf sdf <<< '*command-line-args*'
nil
```

**Problem Statement**
the value of `*command-line-args*` is `nil` at the REPL, even when command line arguments are provided
**Root Cause**
The REPL paths in babashka.main do not bind `*command-line-args*`...
**Fix**
... now they do - main.clj, lines 1024 and 1073
**Tests**
Add tests for the value of `*command-line-args*` in `--repl` mode and with no mode specified (which runs a REPL via a different code branch)

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
