### PR TITLE
Fix #1686: do not fetch deps/invoke java when deps aren't needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ A preview of the next release can be installed from
 - Bump org.flatland/ordered to `1.15.12`.
 - Partially Fix [#1695](https://github.com/babashka/babashka/issues/1695): `--repl` arg handling should consume only one arg (itself) ([@bobisageek](https://github.com/bobisageek))
 - Partially Fix [#1695](https://github.com/babashka/babashka/issues/1695): make `*command-line-args*` value available in the REPL ([@bobisageek](https://github.com/bobisageek))
+- Fix [#1686](https://github.com/babashka/babashka/issues/1686): do not fetch dependencies/invoke java for `version`, `help`, and `describe` options ([@bobisageek](https://github.com/bobisageek))
 
 ## 1.3.190 (2024-04-17)
 

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -94,7 +94,7 @@
 
 (deftest help-opt-test
   (is (every? #(str/includes? (test-utils/bb nil "help") %)
-                 ["Babashka v" "Help:"])))
+        ["Babashka v" "Help:"])))
 
 (deftest describe-opt-test
   (is (every? (partial contains? (bb nil "describe"))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -88,6 +88,18 @@
   (is (not (main/satisfies-min-version? "300.0.0")))
   (is (not (main/satisfies-min-version? "300.0.0-SNAPSHOT"))))
 
+(deftest version-opt-test
+  (is (str/starts-with? (test-utils/bb nil "version")
+        "babashka v")))
+
+(deftest help-opt-test
+  (is (every? #(str/includes? (test-utils/bb nil "help") %)
+                 ["Babashka v" "Help:"])))
+
+(deftest describe-opt-test
+  (is (every? (partial contains? (bb nil "describe"))
+        [:babashka/version :feature/yaml :feature/logging])))
+
 (deftest print-error-test
   (is (thrown-with-msg? Exception #"java.lang.NullPointerException"
                         (bb nil "(subs nil 0 0)"))))


### PR DESCRIPTION
**Problem Statement**
Certain `bb` options (version, help, describe) definitely don't need to fetch dependencies listed in `bb.edn`. When `bb` is invoked with one of these 'fast-path' options and there are deps in `bb.edn`, deps are fetched (and java is called), even though it's not strictly necessary.

**Current State**
`main/exec` always adds deps before it acts on the presence of the fast-path options.

**Change Description**
- The handling of these options gets pulled out to a new function, `exec-without-deps`
- before `exec` gets called, check if any of the fast-path options are present, and if so, call `exec-without-deps` instead of `exec`

**Possible future work**
Since the issue at hand was focused on execution of java (for fetching deps), I only moved the commands that definitely don't need deps. I didn't want to scope creep, but in the future it might be possible to also move `print-deps` and `clojure` out of `exec`. They both might need to invoke java (they call `deps/clojure`), however the thing that potentially groups them together with the fast-path options is that they don't need `sci-ctx`. So, the fast-path options would change from not needing the JVM to not needing SCI (and they would only invoke java if the command needs it).
I want to dig into this a bit more, and if there's a value proposition (maybe save a few milliseconds by not initializing SCI), then I'll open a different issue to go down that road.


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
