### PR TITLE
Fix #1700: catch exceptions from resolving symbolic links during `bb.edn` lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ A preview of the next release can be installed from
 - [#1696](https://github.com/babashka/babashka/issues/1696): add `clojure.core/*source-path*` (points to the same sci var as `*file*`) ([@bobisageek](https://github.com/bobisageek))
 - [#1696](https://github.com/babashka/babashka/issues/1696): add `clojure.main/with-read-known` ([@bobisageek](https://github.com/bobisageek))
 - [#1696](https://github.com/babashka/babashka/issues/1696): add `clojure.core.server/repl-read` ([@bobisageek](https://github.com/bobisageek))
+- [#1700](https://github.com/babashka/babashka/issues/1700): catch exceptions from resolving symbolic links during `bb.edn` lookup ([@bobisageek](https://github.com/bobisageek))
 
 ## 1.3.190 (2024-04-17)
 

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -1149,7 +1149,10 @@ Use bb run --help to show this help output.
 
 (defn resolve-symbolic-link [f]
   (if (and f (fs/exists? f))
-    (str (fs/real-path f))
+    (try
+      (str (fs/real-path f))
+      (catch Exception _
+        f))
     f))
 
 (defn deps-not-needed [opts]

--- a/test/babashka/bb_edn_test.clj
+++ b/test/babashka/bb_edn_test.clj
@@ -531,6 +531,12 @@ even more stuff here\"
   (testing "symlink"
     (is (= {1 {:id 1}} (bb (str (fs/file "test-resources" "symlink-adjacent-bb")))))))
 
+; symlinks that resolve in the /proc fs cause fs/real-path to throw when figuring out bb.edn path (issue #1700)
+(deftest redirection-test
+  (testing "main doesn't throw when input file symlink resolves to 'not real' file"
+    (when (and test-utils/native? (not test-utils/windows?))
+      (is (str/starts-with? (test-utils/bb "(println \"hi\")" "/dev/stdin") "hi")))))
+
 (deftest non-existing-tasks-in-run-gives-exit-code-1
   (is (thrown? Exception (bb "-Sdeps" "{:tasks {foo {:task (run (quote bar))}}}" "foo"))))
 


### PR DESCRIPTION
**Change Description**
- catch exceptions when resolving symlinks during `babashka.main/main`

**Tests**
- Since the failing scenario is somewhat esoteric, and getting predictable ephemeral files was a bit tricky with JVM testing, the test only runs on native, non-windows builds. The test feels like a pretty faithful repro of #1700 (failed with the same exception prior to the change).

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
