### PR TITLE
Support running of new babashka.process tests

### DIFF
--- a/script/lib_tests/run_all_libtests
+++ b/script/lib_tests/run_all_libtests
@@ -2,11 +2,17 @@
 
 set -eo pipefail
 
+: "${BABASHKA_TEST_ENV:=jvm}"
+export BABASHKA_TEST_ENV
+
 if [ "$BABASHKA_TEST_ENV" = "native" ]; then
     BB_CMD="./bb"
 else
     BB_CMD="lein bb"
 fi
+
+export PATH
+PATH=$(pwd)/process/target/test/on-path:$PATH
 
 export BABASHKA_CLASSPATH
 BABASHKA_CLASSPATH=$(clojure -Spath -A:lib-tests)

--- a/script/lib_tests/run_all_libtests.bat
+++ b/script/lib_tests/run_all_libtests.bat
@@ -1,6 +1,10 @@
+if not defined BABASHKA_TEST_ENV set BABASHKA_TEST_ENV=jvm
+
 if "%BABASHKA_TEST_ENV%" EQU "native" (set BB_CMD=.\bb) else (set BB_CMD=lein bb)
 
 set EDN=lib_tests.edn
+
+set PATH=%CD%\process\target\test\on-path;%PATH%
 
 .\bb -f script/lib_tests/bb_edn_from_deps.clj %EDN%
 


### PR DESCRIPTION
Default `BABASHKA_TEST_ENV` to `jvm` for libtests
CI already understands this need, but defaulting in-script avoids having devs to understand/remember it too.

Alter PATH as required for new babashka.process tests.

In support of babashka/process#163, babashka/process#164

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
