### PR TITLE
docs: dev: windows set example misleading

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -112,12 +112,13 @@ Note: If you have to modify any test file or configuration to have it work with
 bb, add an inline comment with prefix `BB-TEST-PATCH:` explaining what you did.
 
 ## Windows
-We have corresponding `.bat` scripts for Windows, examples:
+We have corresponding `.bat` scripts for Windows, examples from a CMD Shell:
 
 ```shell
 script\test.bat
 script\run_lib_tests.bat
-set BABASHKA_TEST_ENV=native & script\run_lib_tests.bat
+set BABASHKA_TEST_ENV=native
+script\run_lib_tests.bat
 ```
 
 ### Enable Windows Symbolic Links


### PR DESCRIPTION
The example I provided implied that the set applied only to the next command. I've learned that this is not the case.

Also: mention what shell examples apply to.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
