### PR TITLE
Document that tests should prefer to hit public APIs

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -22,6 +22,9 @@ agreement, the PR will be merged.
 Each bug fix, change or new feature should be tested well to prevent future
 regressions.
 
+If possible, tests should use public APIs. If the bug is in private/internal
+code, try to trigger it from a public API.
+
 ### Force-push
 
 Please do not use `git push --force` on your PR branch for the following


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

Sort of: I wrote it because I ran into this issue when contributing here: https://github.com/babashka/http-client/issues/73

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

No, it's documentation-only

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Since it's documentation-only this does not seem worth it?