### PR TITLE
Include java.lang.SecurityException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- [#1752](https://github.com/babashka/babashka/issues/1752): include java.lang.SecurityException for java.net.http.HttpClient support
+
 - [#1748](https://github.com/babashka/babashka/issues/1748): add `clojure.core/ensure`
 
 ## 1.12.194 (2024-10-12)

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -328,6 +328,7 @@
           java.lang.ProcessBuilder$Redirect
           java.lang.Runtime
           java.lang.RuntimeException
+          java.lang.SecurityException
           java.lang.Short
           java.lang.StackTraceElement
           java.lang.String
@@ -831,6 +832,7 @@
     RuntimeException java.lang.RuntimeException
     Process java.lang.Process
     ProcessBuilder java.lang.ProcessBuilder
+    SecurityException java.lang.SecurityException
     Short java.lang.Short
     StackTraceElement java.lang.StackTraceElement
     String java.lang.String


### PR DESCRIPTION
java.net.http.HttpClient, included in Babashka, can throw java.lang.SecurityException

https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

Intended in support of https://github.com/babashka/babashka/issues/1752

If this feature is desired, feel free to disregard these PRs and include it directly. I've typo'd the first commit message, and the commits should likely be squashed into one anyway.

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

I looked to see if other exception inclusions contain a test and didn't find any. Happy to include a trivial test if that helps move this forward.

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.


