### PR TITLE
allow subclasses of Throwable to have instance methods called via interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A preview of the next release can be installed from
 
 [Babashka](https://github.com/babashka/babashka): Native, fast starting Clojure interpreter for scripting
 
+## Unreleased
+- [#1785](https://github.com/babashka/babashka/issues/1785): Allow subclasses of `Throwable` to have instance methods invoked ([@bobisageek](https://github.com/bobisageek)) 
+
 ## 1.12.196 (2024-12-24)
 
 - [#1771](https://github.com/babashka/babashka/issues/1771): `*e*` in REPL should contain exception thrown by user, not a wrapped one

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -802,6 +802,8 @@
                                    java.io.Closeable
                                    (instance? java.util.Collection v)
                                    java.util.Collection
+                                   (instance? java.lang.Throwable v)
+                                   java.lang.Throwable
                                    ;; keep commas for merge friendliness
                                    )]
                      ;; (prn :res res)

--- a/test/babashka/interop_test.clj
+++ b/test/babashka/interop_test.clj
@@ -223,3 +223,17 @@
                                                     UserDefinedFileAttributeView
                                                     ^"[Ljava.nio.file.LinkOption;"
                                                     (into-array LinkOption []))))))))
+
+;; exercise a sampling of the superclass resolutions from the :public-class fn in 
+;; babashka.impl.classes/gen-class-map
+(deftest public-class-resolutions
+  (testing "Charset"
+    (is (= "UTF-8" (bb nil "(.displayName (java.nio.charset.Charset/forName  \"UTF-8\"))"))))
+  (testing "InputStream"
+    (is (zero? (bb nil "(with-open [is (java.io.InputStream/nullInputStream)]
+                           (.available is))"))))
+  (testing "Throwable"
+    ; compare output from ex-message to calling .getMessage
+    (let [return-throwable "(try (yaml/parse-string \"abc: def: ghi\") (catch Exception e e))"]
+      (is (= (bb nil (str "(ex-message " return-throwable ")"))
+             (bb nil (str "(.getMessage " return-throwable ")")))))))


### PR DESCRIPTION
Apart from the addition of `Throwable`, the added tests are aimed at covering a couple of the resolutions. So, there's no app code change that's applicable to `Charset` or `InputStream`, but I wanted to cover a few of the superclasses so that if a regression comes up in the future, it might be more evident whether it's an individual superclass that's impacted, or the whole `:public-class` fn.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
