### PR TITLE
WIP: FreeBSD installer

### DIFF
--- a/.circleci/script/gen_ci.clj
+++ b/.circleci/script/gen_ci.clj
@@ -112,7 +112,7 @@ script/uberjar
 cp $jar /tmp/release
 # openjdk standalone
 GRAALVM_HOME= script/uberjar
-cp $jar /tmp/release/target/babashka-$VERSION-standalone-openjdk.jar
+cp $jar /tmp/release/babashka-$VERSION-standalone-openjdk.jar
 # reflection.json
 java -jar $jar script/reflection.clj
 reflection=\"babashka-$VERSION-reflection.json\"

--- a/.circleci/script/gen_ci.clj
+++ b/.circleci/script/gen_ci.clj
@@ -78,7 +78,7 @@
   (gen-job
    shorted?
    (ordered-map
-    :docker            [{:image "circleci/clojure:openjdk-11-lein-2.9.8-bullseye"}]
+    :docker            [{:image "circleci/clojure:openjdk-23-lein-2.9.8-bullseye"}]
     :working_directory "~/repo"
     :environment       {:LEIN_ROOT         "true"
                         :BABASHKA_PLATFORM "linux"
@@ -105,12 +105,15 @@ script/test\nscript/run_lib_tests")
       (run
         "Create uberjar"
         "mkdir -p /tmp/release
-script/uberjar
 VERSION=$(cat resources/BABASHKA_VERSION)
 jar=target/babashka-$VERSION-standalone.jar
+# graalvm standalone
+script/uberjar
 cp $jar /tmp/release
-export PATH=$GRAALVM_HOME/bin:$PATH
-export JAVA_HOME=$GRAALVM_HOME
+# openjdk standalone
+GRAALVM_HOME= script/uberjar
+cp $jar /tmp/release/target/babashka-$VERSION-standalone-openjdk.jar
+# reflection.json
 java -jar $jar script/reflection.clj
 reflection=\"babashka-$VERSION-reflection.json\"
 java -jar \"$jar\" --config .build/bb.edn --deps-root . release-artifact \"$jar\"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 - [#1785](https://github.com/babashka/babashka/issues/1785): Allow subclasses of `Throwable` to have instance methods invoked ([@bobisageek](https://github.com/bobisageek)) 
+- Support FreeBSD in `./install` via openjdk
 
 ## 1.12.196 (2024-12-24)
 

--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ $ ./install --static
 
 > Note: babashka has severe performance penalties on FreeBSD as it runs on openjdk
 
-Requirements: OpenJDK 23
+Requirements: OpenJDK 23, Bash, Curl
 
 ``` shell
-$ pkg install openjdk23
+$ pkg install openjdk23 bash curl
 $ curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
 $ chmod +x install
 $ ./install

--- a/README.md
+++ b/README.md
@@ -226,9 +226,31 @@ $ chmod +x install
 $ ./install --static
 ```
 
+### FreeBSD
+
+> Note: babashka has severe performance penalties on FreeBSD as it runs on openjdk
+
+Requirements: OpenJDK 23
+
+``` shell
+$ pkg install openjdk23
+$ curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+$ chmod +x install
+$ ./install
+```
+
+GraalVM does not support BSD, hence startup time will extremely slow under OpenJDK compared to native binaries.
+
+The `bb` command is thin wrapper calling `/usr/local/openjdk23/bin/java -jar <lib>/bb.jar "$@"`.
+The lib directory can be configured with `--lib` relative to the current directory.
+
+``` shell
+$ ./install --lib lib/babashka
+```
+
 ### Installer script
 
-Install via the installer script for linux and macOS:
+Install via the installer script for linux, macOS and BSD:
 
 ``` shell
 $ curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
@@ -246,20 +268,20 @@ $ ./install --dir .
 To install a specific version, the script also supports `--version`:
 
 ``` shell
-$ ./install --dir . --version 0.4.1
+$ ./install --dir . --version 1.12.196
 ```
 
 To force the download of the zip archive to a different directory than `/tmp`
 use the `--download-dir` argument:
 
 ``` shell
-$ ./install --dir . --version 0.4.1 --download-dir .
+$ ./install --dir . --version 1.12.196 --download-dir .
 ```
 
 On Linux, if you want to install the static binary version:
 
 ``` shell
-$ ./install --dir . --version 0.4.1 --download-dir . --static
+$ ./install --dir . --version 1.12.196 --download-dir . --static
 ```
 
 In case you want to check the download, you can use the `--checksum` option.

--- a/install
+++ b/install
@@ -192,8 +192,8 @@ mkdir -p "$download_dir" && (
     fi
 
     if [[ "$platform" == "bsd" ]]; then
-      echo '#!/usr/bin/env bash'                                       >  "bb"
-      echo '/usr/local/openjdk23/bin/java -jar '$lib_dir'/bb.jar "$@"' >> "bb"
+      echo '#!/usr/bin/env bash'                                         >  "bb"
+      echo '/usr/local/openjdk23/bin/java -jar "'$lib_dir'/bb.jar" "$@"' >> "bb"
       chmod +x "bb"
 
       if [ -f "$lib_dir/bb.jar" ]; then

--- a/install
+++ b/install
@@ -173,8 +173,6 @@ if [[ "$platform" == "bsd" ]]; then
   lib_dir=$(readlink -f $lib_dir)
 fi
 
-echo after
-
 # Running this part in a subshell so when it finishes we go back to the previous directory
 mkdir -p "$download_dir" && (
     cd "$download_dir"

--- a/install
+++ b/install
@@ -7,17 +7,20 @@ checksum=""
 static_binary="false"
 default_install_dir="/usr/local/bin"
 install_dir="$default_install_dir"
+default_lib_dir="/usr/local/lib/babashka"
+lib_dir="$default_lib_dir"
 download_dir=""
 dev_build=""
 
 print_help() {
-    echo "Installs latest (or specific) version of babashka. Installation directory defaults to /usr/local/bin."
+    echo "Installs latest (or specific) version of babashka. Installation directory defaults to ${default_install_dir}."
     echo -e
     echo "Usage:"
-    echo "install [--dir <dir>] [--download-dir <download-dir>] [--version <version>] [--checksum <checksum>] [--static]"
+    echo "install [--dir <dir>] [--download-dir <download-dir>] [--version <version>] [--checksum <checksum>] [--static] [--lib <lib-dir>]"
     echo -e
     echo "Defaults:"
     echo " * Installation directory: ${default_install_dir}"
+    echo " * Lib directory (BSD only): ${default_lib_dir}"
     echo " * Download directory: temporary"
     if [[ -z "$checksum" ]]; then
         echo " * Checksum: no"
@@ -35,6 +38,11 @@ do
     case "$key" in
         --dir)
             install_dir="$2"
+            shift
+            shift
+            ;;
+        --lib)
+            lib_dir="$2"
             shift
             shift
             ;;
@@ -89,6 +97,7 @@ fi
 case "$(uname -s)" in
     Linux*)  platform=linux;;
     Darwin*) platform=macos;;
+    FreeBSD*) platform=bsd;;
 esac
 
 # Ugly ugly conversion of version to a comparable number
@@ -115,7 +124,10 @@ case "$(uname -m)" in
        ;;
 esac
 
-if [[ 10#$vernum -le 10#000002013 ]]; then
+if [[ "$platform" == "bsd" ]]; then
+    ext=
+    util=
+elif [[ 10#$vernum -le 10#000002013 ]]; then
     ext="zip"
     util="$(which unzip) -qqo"
 else
@@ -125,6 +137,8 @@ fi
 
 case "$platform-$static_binary" in
     linux-true) filename="babashka-$version-$platform-$arch-static."$ext
+                ;;
+    bsd-*)      filename="babashka-$version-standalone-openjdk.jar"
                 ;;
     *-true)     >&2 echo "Static binaries are only available in Linux platform! Using the non-static one..."
                 filename="babashka-$version-$platform-$arch."$ext
@@ -154,12 +168,22 @@ else
     exit 1
 fi
 
+if [[ "$platform" == "bsd" ]]; then
+  mkdir -p "$lib_dir"
+  lib_dir=$(readlink -f $lib_dir)
+fi
+
+echo after
+
 # Running this part in a subshell so when it finishes we go back to the previous directory
 mkdir -p "$download_dir" && (
     cd "$download_dir"
     echo -e "Downloading $download_url to $download_dir"
 
-    curl -o "$filename" -sL "$download_url"
+    if [[ $(curl -o "$filename" -sL "$download_url" -w "%{http_code}") -ne 200 ]]; then
+      >&2 echo "Failed to download $download_url"
+      exit 1
+    fi
     if [[ -n "$checksum" ]]; then
         if ! echo "$checksum *$filename" | $sha256sum_cmd --check --status; then
             >&2 echo "Failed checksum on $filename"
@@ -168,8 +192,21 @@ mkdir -p "$download_dir" && (
             exit 1
         fi
     fi
-    $util "$filename"
-    rm -f "$filename"
+
+    if [[ "$platform" == "bsd" ]]; then
+      echo '#!/usr/bin/env bash'                                       >  "bb"
+      echo '/usr/local/openjdk23/bin/java -jar '$lib_dir'/bb.jar "$@"' >> "bb"
+      chmod +x "bb"
+
+      if [ -f "$lib_dir/bb.jar" ]; then
+          echo "Moving $lib_dir/bb.jar to $lib_dir/bb.jar.old"
+          mv -f "$lib_dir/bb.jar" "$lib_dir/bb.jar.old"
+      fi
+      mv "$filename" "$lib_dir/bb.jar"
+    elif [[ -n "$util" ]]; then
+      $util "$filename"
+      rm -f "$filename"
+    fi
 )
 
 if [[ "$download_dir" != "$install_dir" ]]


### PR DESCRIPTION
GraalVM doesn't support on FreeBSD. To emulate a compiled executable, we use an uberjar compiled by openjdk23 (corresponding to the current graalvm version) executed with openjdk23.

This PR adds an extra uberjar file to circleci releases that is compiled by openjdk23. Another jar is needed because the existing uberjar only works under graalvm.

I noticed the curl call in the installer does not check the response code so I added that. This needs further testing.

TODO
- [ ] test installer on other platforms
- [ ] test installer on freebsd

Locally tested by:
1. commenting out the curl command in ./install
2. ./script/uberjar
3. mkdir -p download
4. cp target/babashka-1.12.197-SNAPSHOT-standalone.jar download/babashka-1.12.196-standalone-openjdk.jar
5. ./install --dir . --lib lib --download-dir download
6. ./bb -e :works

</hr>

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
