### PR TITLE
Make install-script wget-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- [#1815](https://github.com/babashka/babashka/issues/1815): Make install-script wget-compatible
 - Bump `fs` to `0.5.25`
 - Bump `jsoup` to `1.20.1`
 - Bump `edamame` to `1.4.30`

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Install via the installer script for linux and macOS:
 
 ``` shell
 $ curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+# or
+$ wget -qO install https://raw.githubusercontent.com/babashka/babashka/master/install
 $ chmod +x install
 $ ./install
 ```

--- a/install
+++ b/install
@@ -29,6 +29,32 @@ print_help() {
     exit 1
 }
 
+has() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+fetch() {
+    local url=$1
+    local outfile=${2:-}
+
+    if has wget; then
+        if [[ -n $outfile ]]; then
+            wget -qO "$outfile" "$url"
+        else
+            wget -qO - "$url"
+        fi
+    elif has curl; then
+        if [[ -n $outfile ]]; then
+            curl -fsSL "$url" -o "$outfile"
+        else
+            curl -fsSL "$url"
+        fi
+    else
+        >&2 echo "Either 'wget' or 'curl' needs to be on PATH!"
+        exit 1
+    fi
+}
+
 while [[ $# -gt 0 ]]
 do
     key="$1"
@@ -80,9 +106,9 @@ fi
 
 if [[ "$version" == "" ]]; then
     if [[ "$dev_build" == "true" ]]; then
-        version="$(curl -sL https://raw.githubusercontent.com/babashka/babashka/master/resources/BABASHKA_VERSION)"
+        version="$(fetch https://raw.githubusercontent.com/babashka/babashka/master/resources/BABASHKA_VERSION)"
     else
-        version="$(curl -sL https://raw.githubusercontent.com/babashka/babashka/master/resources/BABASHKA_RELEASED_VERSION)"
+        version="$(fetch https://raw.githubusercontent.com/babashka/babashka/master/resources/BABASHKA_RELEASED_VERSION)"
     fi
 fi
 
@@ -144,9 +170,9 @@ download_url="https://github.com/babashka/$repo/releases/download/v$version/$fil
 
 # macOS only have shasum available by default
 # Some Linux distros (RHEL-like) only have sha256sum available by default (others have both)
-if command -v sha256sum >/dev/null; then
+if has sha256sum; then
     sha256sum_cmd="sha256sum"
-elif command -v shasum >/dev/null; then
+elif has shasum; then
     sha256sum_cmd="shasum -a 256"
 else
     >&2 echo "Either 'sha256sum' or 'shasum' needs to be on PATH for '--checksum' flag!"
@@ -159,7 +185,7 @@ mkdir -p "$download_dir" && (
     cd "$download_dir"
     echo -e "Downloading $download_url to $download_dir"
 
-    curl -o "$filename" -sL "$download_url"
+    fetch "$download_url" "$filename"
     if [[ -n "$checksum" ]]; then
         if ! echo "$checksum *$filename" | $sha256sum_cmd --check --status; then
             >&2 echo "Failed checksum on $filename"


### PR DESCRIPTION
Closes #1815 

Verify with e.g.:
```
$ docker run -it ubuntu:latest bash -c 'apt-get update && apt-get -y install wget && bash < <(wget -qO- https://raw.githubusercontent.com/eval/babashka/refs/heads/install-supports-wget/install) && bb version'
```