### PR TITLE
Add org.jline.keymap.BindingReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ A preview of the next release can be installed from
 ## Unreleased
 
 - nREPL: lock output stream to prevent interleaved bencode frames from concurrent writes
+- Add `org.jline.keymap.BindingReader` for reading key bindings in terminal applications
 
 ## 1.12.218 (2026-04-20)
 

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -736,6 +736,7 @@
           org.jline.reader.ParsedLine
           org.jline.reader.EOFError
           org.jline.keymap.KeyMap
+          org.jline.keymap.BindingReader
           org.jline.terminal.Terminal$SignalHandler
           org.jline.terminal.spi.TerminalProvider
           org.jline.terminal.spi.TerminalExt ;; cast Terminal to this and then .getProvider

--- a/test/babashka/jline_test.clj
+++ b/test/babashka/jline_test.clj
@@ -157,6 +157,34 @@
                       (.bind km :action "a")
                       (= :action (.getBound km "a"))))))))
 
+(deftest jline-binding-reader-test
+  (testing "BindingReader class is available"
+    (is (true? (bb '(class? org.jline.keymap.BindingReader)))))
+  (testing "BindingReader.readBinding reads a bound key sequence from a terminal"
+    ;; Real interop exercise: construct a BindingReader over the terminal's
+    ;; NonBlockingReader and call .readBinding so dispatch is actually checked,
+    ;; not just construction. Uses a PipedInputStream kept open until we close
+    ;; the terminal, for the same reason as jline-linereader-test above.
+    ;; "[A" is the up-arrow escape sequence; readBinding consumes the
+    ;; whole sequence and returns the bound value.
+    (is (= "up"
+           (bb '(let [pipe-out (java.io.PipedOutputStream.)
+                      input (java.io.PipedInputStream. pipe-out)
+                      _ (do (.write pipe-out (.getBytes "[A"))
+                            (.flush pipe-out))
+                      output (java.io.ByteArrayOutputStream.)
+                      terminal (-> (org.jline.terminal.TerminalBuilder/builder)
+                                   (.dumb true)
+                                   (.streams input output)
+                                   (.build))
+                      km (doto (org.jline.keymap.KeyMap.)
+                           (.bind "up" "[A"))
+                      br (org.jline.keymap.BindingReader. (.reader terminal))]
+                  (try
+                    (.readBinding br km)
+                    (finally
+                      (.close terminal)))))))))
+
 (deftest jline-attributes-test
   (testing "Attributes can be constructed and used"
     (is (true? (bb '(let [terminal (-> (org.jline.terminal.TerminalBuilder/builder)


### PR DESCRIPTION
Register BindingReader so terminal/TUI scripts can read key bindings from a KeyMap, completing the input side of the bundled JLine API (KeyMap was already available, its reader was not).

Add a jline-test exercising both class availability and an actual .readBinding call over a terminal reader. Verified on JVM and native.

