### PR TITLE
Add FreeBSD instructions for babashka.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,17 @@ linux binary.
 can be installed via [pkg(8)](https://man.freebsd.org/cgi/man.cgi?query=pkg).
 
 Install:
-    pkg install babashka
+
+``` shell
+pkg install babashka
+```
+
     
 Upgrade:
-    pkg upgrade babashka
+
+``` shell
+pkg upgrade babashka
+```
 
 The `lang/babashka` port makes use of the FreeBSD Linux emulation layer aka [Linuxulator](https://docs.freebsd.org/en/books/handbook/linuxemu/) to run the static binaries from [Github Releases](https://github.com/babashka/babashka/releases). In order for this package to work in FreeBSD it is therefore needed to have the Linux ABI enabled at boot time and the service to be started.
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ The `lang/babashka` port makes use of the FreeBSD Linux emulation layer aka [Lin
 This can be done by the following commands in the shell
 
 ``` shell
-# sysrc linux_enable="YES"
-# service linux start
+sysrc linux_enable="YES"
+service linux start
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,27 @@ linux binary.
 
     yay -S babashka-bin
 
+### FreeBSD
+
+`babashka` is [available](https://www.freshports.org/lang/babashka) in the [FreeBSD Ports Collection](https://github.com/freebsd/freebsd-ports) and
+can be installed via [pkg(8)](https://man.freebsd.org/cgi/man.cgi?query=pkg).
+
+Install:
+    pkg install babashka
+    
+Upgrade:
+    pkg upgrade babashka
+
+The `lang/babashka` port makes use of the FreeBSD Linux emulation layer aka [Linuxulator](https://docs.freebsd.org/en/books/handbook/linuxemu/) to run the static binaries from [Github Releases](https://github.com/babashka/babashka/releases). In order for this package to work in FreeBSD it is therefore needed to have the Linux ABI enabled at boot time and the service to be started.
+
+This can be done by the following commands in the shell
+
+``` shell
+# sysrc linux_enable="YES"
+# service linux start
+```
+
+
 ### asdf
 
 [asdf](https://github.com/asdf-vm/asdf) is an extendable version manager for linux and macOS. Note that asdf will add significant startup time to any babashka script, consider using [mise](#mise) instead.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ Install:
 ``` shell
 pkg install babashka
 ```
-
     
 Upgrade:
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Upgrade:
 pkg upgrade babashka
 ```
 
-The `lang/babashka` port makes use of the FreeBSD Linux emulation layer aka [Linuxulator](https://docs.freebsd.org/en/books/handbook/linuxemu/) to run the static binaries from [Github Releases](https://github.com/babashka/babashka/releases). In order for this package to work in FreeBSD it is therefore needed to have the Linux ABI enabled at boot time and the service to be started.
+The `lang/babashka` port makes use of the FreeBSD Linux emulation layer aka [Linuxulator](https://docs.freebsd.org/en/books/handbook/linuxemu/) to run the static binaries from [Github Releases](https://github.com/babashka/babashka/releases). In order for this package to work in FreeBSD it is therefore necessary to have the Linux ABI enabled at boot time and the service to be started.
 
 This can be done by the following commands in the shell
 


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - Even though the issue was closed https://github.com/babashka/babashka/issues/721 , it was not resolved. This PR adds necessary instructions to get babashka working in FreeBSD.

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

Hello @borkdude  / @lispyclouds 

I am a package maintainer from FreeBSD and would like to inform you that we now have a [package for FreeBSD](https://cgit.freebsd.org/ports/tree/lang/babashka/Makefile) that can be installed via the FreeBSD's package manager.

There was also a request in the FreeBSD forums requesting for a port
- https://forums.freebsd.org/threads/porting-babashka-graalvm-clojure-dialect-or-is-it-ok-to-create-a-port-of-software-that-depends-on-linux-compat.99270/

This PR updates the `README.md` with the instructions to install and run it in FreeBSD.

**Upstream port details**

- https://www.freshports.org/lang/babashka
- https://cgit.freebsd.org/ports/tree/lang/babashka/
- [Poudriere Build results (amd64)](https://pkg-status.freebsd.org/beefy23/build.html?mastername=150amd64-default&build=50aa2c1cc258)
  - [Build Logs](https://pkg-status.freebsd.org/beefy23/data/150amd64-default/50aa2c1cc258/logs/babashka-1.12.218.log)

As a prerequisite I have also raised a PR updating the CI doing the FreeBSD checks.
- https://github.com/babashka/freebsd-compat-test/pull/1

As of now the port is available in the `latest` catalogue, and it would be made available in the `quarterly` catalogue in the coming month. The instructions for FreeBSD at the time of writing this PR would only work if you point `pkg(8)` to the `latest` catalogue. (We can defer the merge once the `quarterly` branch is cut).
 
I have not updated the instructions in the Wiki (we can do also defer this until the PR is reviewed and merged).
- https://github.com/babashka/babashka/wiki/FreeBSD

**Benchmark on bare-metal FreeBSD**

I put in some of the tests I ran in my FreeBSD instance for reference. You can also check the GHA log to see the details of the tests run in the CI.
- https://github.com/babashka/freebsd-compat-test/actions/runs/26682336108/job/78645171347?pr=1

Tests from https://github.com/borkdude/cream#cream-vs-babashka

```
# bb -cp "$(clojure -Spath -Sdeps '{:deps {dev.weavejester/medley {:mvn/version "1.9.0"}}}')" -e '(time (require (quote [medley.core :as mc]))) (time (dotimes [i 100000] (mc/greatest 5 2 1 3 4)))'
"Elapsed time: 15.289707 msecs"
"Elapsed time: 145.200319 msecs"
#
```

```
# bb -cp "$(clojure -Spath -Sdeps '{:deps {camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}}}')" -e '(time (require (quote [camel-snake-kebab.core :as csk]))) (time (dotimes [i 100000] (csk/->SCREAMING_SNAKE_CASE "I am constant")))'
"Elapsed time: 14.116047 msecs"
"Elapsed time: 1567.249085 msecs"
#
```

Loop provided by @lispyclouds 
```
# bb -e "(time (let [x 0 j 10000000] (loop [i 0 j 10000000] (if (zero? j) i (recur (inc i) (dec j))))))"
"Elapsed time: 453.580157 msecs"
10000000
#
```

Pod test provided by @lispyclouds 
```
# bb -e "(require '[babashka.pods :as pods]) (pods/load-pod 'org.babashka/go-sqlite3 \"0.3.9\") (require '[pod.babashka.go-sqlite3 :as sqlite]) (prn (sqlite/query \"/tmp/foo.db\" [\"select 1+1\"]))"
[{:1+1 2}]
```

Looking forward to the review.