### PR TITLE
Add more lock classes (#1985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ A preview of the next release can be installed from
   - `clojure.lang.PersistentVector$ChunkedSeq`
   - `java.util.AbstractCollection`
   - `java.util.Queue`
+- [#1985](https://github.com/babashka/babashka/issues/1982): Add the following classes to `babashka.impl.classes/classes`
+  - `java.util.concurrent.locks.Condition`
+  - `java.util.concurrent.locks.Lock`
+  - `java.util.concurrent.locks.LockSupport`
 
 ## 1.12.218 (2026-04-20)
 

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -608,6 +608,9 @@
           java.util.concurrent.Executors
           java.util.concurrent.TimeUnit
           java.util.concurrent.CompletionStage
+          java.util.concurrent.locks.Condition
+          java.util.concurrent.locks.Lock
+          java.util.concurrent.locks.LockSupport
           java.util.concurrent.locks.ReentrantLock
           java.util.concurrent.ThreadLocalRandom
           java.util.concurrent.ConcurrentHashMap
@@ -963,6 +966,8 @@
                                    java.util.concurrent.ScheduledExecutorService
                                    (instance? java.util.concurrent.ExecutorService v)
                                    java.util.concurrent.ExecutorService
+                                   (instance? java.util.concurrent.locks.Condition v)
+                                   java.util.concurrent.locks.Condition
                                    (instance? java.util.Iterator v)
                                    java.util.Iterator
                                    (instance? javax.crypto.SecretKey v)

--- a/test/babashka/interop_test.clj
+++ b/test/babashka/interop_test.clj
@@ -445,3 +445,31 @@
   (.update standalone-digest data)
 
   (= (seq (.digest standalone-digest)) (seq (.digest sink-digest))))"))))
+
+(deftest java-util-concurrent-locks-test
+  (is (true? (bb nil "(ns script
+  (:import [java.util.concurrent.locks Condition Lock ReentrantLock]
+           [java.util.concurrent TimeUnit]))
+
+(let [result     (volatile! 1)
+      ^Lock lock (ReentrantLock.)
+      cnd        (.newCondition lock)]
+  (try (.lock lock)
+       (future
+         (.lock lock)
+         (vswap! result inc)
+         (.signal cnd)
+         (.unlock lock))
+       (Thread/sleep 1)
+       (.await cnd 10 TimeUnit/MILLISECONDS)
+       (vswap! result * 2)
+       (finally (.unlock lock)))
+  (= 4 @result))")))
+  (is (true? (bb nil "(ns script
+  (:import [java.util.concurrent.locks LockSupport]))
+
+(let [thread (Thread/currentThread)
+      t0     (System/nanoTime)]
+  (future (Thread/sleep 10) (LockSupport/unpark thread))
+  (LockSupport/parkNanos 1e9)
+  (< (- (System/nanoTime) t0) 5e8))"))))


### PR DESCRIPTION
This PR adds three new lock classes to Babashka in order to support TeensyP, a small TCP server for Clojure.

  - `java.util.concurrent.locks.Condition`
  - `java.util.concurrent.locks.Lock`
  - `java.util.concurrent.locks.LockSupport`

This PR resolves issue #1985.

As part of this PR:

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.