### PR TITLE
Add more NIO classes, fixes #1986

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,15 @@ A preview of the next release can be installed from
   - `clojure.lang.PersistentVector$ChunkedSeq`
   - `java.util.AbstractCollection`
   - `java.util.Queue`
-- [#1985](https://github.com/babashka/babashka/issues/1982): Add the following classes to `babashka.impl.classes/classes`
+- [#1985](https://github.com/babashka/babashka/issues/1985): Add the following classes to `babashka.impl.classes/classes`
   - `java.util.concurrent.locks.Condition`
   - `java.util.concurrent.locks.Lock`
   - `java.util.concurrent.locks.LockSupport`
+- [#1986](https://github.com/babashka/babashka/issues/1986): Add the following classes to `babashka.impl.classes/classes`
+  - `java.net.StandardSocketOptions`
+  - `java.nio.channels.CancelledKeyException`
+  - `java.nio.channels.Selector`
+  - `java.nio.channels.SelectionKey`
 
 ## 1.12.218 (2026-04-20)
 

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -446,6 +446,7 @@
           java.net.ServerSocket
           java.net.Socket
           java.net.SocketException
+          java.net.StandardSocketOptions
           ~@(when has-domain-sockets?
               '[java.net.UnixDomainSocketAddress])
           java.net.UnknownHostException
@@ -465,11 +466,14 @@
                 java.nio.file.OpenOption
                 java.nio.file.StandardOpenOption
                 java.nio.channels.ByteChannel
+                java.nio.channels.CancelledKeyException
                 java.nio.channels.Channels
                 java.nio.channels.FileChannel
                 java.nio.channels.FileChannel$MapMode
                 java.nio.channels.ReadableByteChannel
                 java.nio.channels.WritableByteChannel
+                java.nio.channels.Selector
+                java.nio.channels.SelectionKey
                 java.nio.channels.ServerSocketChannel
                 java.nio.channels.SocketChannel
                 java.nio.charset.Charset
@@ -931,6 +935,10 @@
                                    java.nio.CharBuffer
                                    (instance? java.nio.channels.FileChannel v)
                                    java.nio.channels.FileChannel
+                                   (instance? java.nio.channels.Selector v)
+                                   java.nio.channels.Selector
+                                   (instance? java.nio.channels.SelectionKey v)
+                                   java.nio.channels.SelectionKey
                                    (instance? java.nio.channels.ServerSocketChannel v)
                                    java.nio.channels.ServerSocketChannel
                                    (instance? java.nio.channels.SocketChannel v)

--- a/test/babashka/interop_test.clj
+++ b/test/babashka/interop_test.clj
@@ -473,3 +473,28 @@
   (future (Thread/sleep 10) (LockSupport/unpark thread))
   (LockSupport/parkNanos 1e9)
   (< (- (System/nanoTime) t0) 5e8))"))))
+
+(deftest java-nio-channels-test
+  (is (true? (bb nil "(ns script
+  (:import [java.net InetSocketAddress Socket StandardSocketOptions]
+           [java.nio.channels CancelledKeyException Selector SelectionKey
+            ServerSocketChannel]))
+
+(let [sel  (Selector/open)
+      ch   (doto (ServerSocketChannel/open)
+             (.configureBlocking false)
+             (.setOption StandardSocketOptions/SO_REUSEADDR true)
+             (.bind (InetSocketAddress. 0))
+             (.register sel SelectionKey/OP_ACCEPT))
+      port (.getPort (.getLocalAddress ch))
+      done (atom false)]
+  (future (Thread/sleep 10) (.close (Socket. \"localhost\" port)))
+  (.select sel 1000)
+  (doseq [key (.selectedKeys sel)]
+    (try (when (.isAcceptable key)
+           (.accept (.channel key))
+           (reset! done true))
+         (catch CancelledKeyException _ex)))
+  (.close sel)
+  (.close ch)
+  @done)"))))


### PR DESCRIPTION
This pull request adds additional NIO classes that TeensyP (and likely any NIO TCP server) needs to function. I've included a test which sets up a very minimal NIO server to test it works.

This closes issue #1986.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
