### PR TITLE
Allow reify of Closeable and AutoCloseable, fixes #1988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ A preview of the next release can be installed from
   - `java.nio.channels.Selector`
   - `java.nio.channels.SelectionKey`
 - [#1987](https://github.com/babashka/babashka/issues/1987): Allow the `remove` method to be used on `Iterator`
+- [#1988](https://github.com/babashka/babashka/issues/1988): Allow `java.io.Closeable` and `java.lang.AutoCloseable` to be reified
 
 ## 1.12.218 (2026-04-20)
 

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
          "impl-java/src"],
  :deps {org.clojure/clojure {:mvn/version "1.12.5"},
         org.babashka/sci {:local/root "sci"}
-        org.babashka/babashka.impl.java {:mvn/version "0.1.19"}
+        org.babashka/babashka.impl.java {:mvn/version "0.1.20"}
         org.babashka/sci.impl.types {:mvn/version "0.0.3"}
         babashka/babashka.curl {:local/root "babashka.curl"}
         babashka/fs {:local/root "fs"}

--- a/impl-java/build.clj
+++ b/impl-java/build.clj
@@ -3,7 +3,7 @@
             [clojure.tools.build.api :as b]))
 
 (def lib 'org.babashka/babashka.impl.java)
-(def version "0.1.19")
+(def version "0.1.20")
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))

--- a/impl-java/src/babashka/impl/reify2/interfaces.clj
+++ b/impl-java/src/babashka/impl/reify2/interfaces.clj
@@ -2,6 +2,7 @@
 
 (def interfaces [java.nio.file.FileVisitor
                  java.nio.file.DirectoryStream$Filter
+                 java.io.Closeable
                  java.io.FileFilter
                  java.io.FilenameFilter
                  clojure.lang.Associative
@@ -19,6 +20,7 @@
                  clojure.lang.IPersistentStack
                  clojure.lang.Reversible
                  clojure.lang.Seqable
+                 java.lang.AutoCloseable
                  java.lang.Iterable
                  java.lang.Runnable
                  java.net.http.WebSocket$Listener

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [nrepl/bencode "1.2.0"]
                  [borkdude/sci.impl.reflector "0.0.5"]
                  [org.babashka/sci.impl.types "0.0.3"]
-                 [org.babashka/babashka.impl.java "0.1.19"]
+                 [org.babashka/babashka.impl.java "0.1.20"]
                  [org.clojure/core.async "1.8.741"]
                  [org.clojure/test.check "1.1.1"]
                  [com.github.clj-easy/graal-build-time "1.0.5"]

--- a/test/babashka/interop_test.clj
+++ b/test/babashka/interop_test.clj
@@ -512,3 +512,17 @@
           (.remove iter))
         (recur))))
   (= #{1 3 5 7 9} s))"))))
+
+(deftest reify-closeable-test
+  (is (true? (bb nil "(ns script
+  (:import [java.io Closeable]))
+
+(let [v (volatile! false)]
+  (with-open [_ (reify Closeable (close [_] (vreset! v true)))])
+  @v)")))
+  (is (true? (bb nil "(ns script
+  (:import [java.lang AutoCloseable]))
+
+(let [v (volatile! false)]
+  (with-open [_ (reify AutoCloseable (close [_] (vreset! v true)))])
+  @v)"))))


### PR DESCRIPTION
This PR fixes #1988 and adds `java.io.Closeable` and `java.lang.AutoCloseable` to the list of allowed reify interfaces.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
