### PR TITLE
Add the Elements class from Jsoup (#2003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- [#2003](https://github.com/babashka/babashka/issues/2003): add `org.jsoup.select.Elements` for `Element.select`
 - Tasks: `:exec-fn` (a function) or `:cmd` (a command tree) on a task routes it through `babashka.cli/dispatch`, giving it `--help`, shell completion and subcommands. Options, docstring and `:enum` come from the function's `:org.babashka/cli` metadata, like `bb -x`
 - Tasks: `:cli` on a task holds babashka.cli options that have no function to live on, such as an `:epilog` on a command group. A map, or a symbol naming a var of one for options that include functions, such as an `:error-fn`. At the `:tasks` level the same entry applies to every CLI task
 - Tasks: `:doc` may be a vector of lines

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -713,6 +713,7 @@
           org.jsoup.nodes.XmlDeclaration
           org.jsoup.parser.Tag
           org.jsoup.parser.Parser
+          org.jsoup.select.Elements
           ;; jline
           org.jline.terminal.Terminal
           org.jline.terminal.TerminalBuilder

--- a/test/babashka/interop_test.clj
+++ b/test/babashka/interop_test.clj
@@ -313,7 +313,9 @@
       (is (= (bb nil (str "(ex-message " return-throwable ")"))
              (bb nil (str "(.getMessage " return-throwable ")"))))))
   (testing "jsoup Element"
-    (is (= "form" (bb nil "(.tagName (first (.getElementsByTag (org.jsoup.Jsoup/parseBodyFragment \"<form></form>\") \"form\")))")))))
+    (is (= "form" (bb nil "(.tagName (first (.getElementsByTag (org.jsoup.Jsoup/parseBodyFragment \"<form></form>\") \"form\")))"))))
+  (testing "jsoup Elements via select"
+    (is (= "1" (bb nil "(.text (.first (.select (org.jsoup.Jsoup/parse \"<ul><li>1</li><li>2</li></ul>\") \"ul>li\")))")))))
 
 (deftest cached-thread-pool
   (is (= 3 (bb nil "(import '(java.util.concurrent Executors ExecutorService))


### PR DESCRIPTION
`Elements` is the result from the `Element.select` method and basically opens this way of querying the DOM up.

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/babashka/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/babashka/blob/master/CHANGELOG.md) file with a description of the addressed issue.
