### PR TITLE
Fetch source tarballs with retries, mirrors and a cache

### DIFF
--- a/.circleci/script/gen_ci.clj
+++ b/.circleci/script/gen_ci.clj
@@ -174,7 +174,9 @@ java -jar \"$jar\" --config .build/bb.edn --deps-root . release-artifact \"$refl
                                           (when (not= "mac" platform)
                                             (run "Install native dev tools"
                                               (if (and static? musl? (not= "aarch64" arch))
-                                                (str base-install-cmd "\nsudo -E script/setup-musl")
+                                                (str base-install-cmd
+                                                     "\nexport BABASHKA_TARBALL_CACHE=\"$HOME/.cache/babashka-tarballs\""
+                                                     "\nsudo -E script/setup-musl")
                                                 ;; non-musl linux builds link zlib statically
                                                 (str base-install-cmd "\nsudo -E script/setup-zlib"))))
                                           ;; after dev tools: the probe needs cc
@@ -195,7 +197,11 @@ java -jar \"$jar\" --config .build/bb.edn --deps-root . release-artifact \"$refl
                                             (str/join "\n" ["export BABASHKA_RELEASE=true"
                                                             ".circleci/script/release"]))
                                           {:save_cache
-                                           {:paths ["~/.m2" "~/graalvm"]
+                                           {:paths ["~/.m2" "~/graalvm"
+                                                    ;; source tarballs, so a
+                                                    ;; dead upstream only hurts
+                                                    ;; on a cache miss
+                                                    "~/.cache/babashka-tarballs"]
                                             :key   cache-key}}
                                           {:store_artifacts {:path        "/tmp/release"
                                                              :destination "release"}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- Building babashka from source no longer fails when a single upstream host is unreachable: the musl and zlib tarballs are fetched with retries, from mirrors, and cached per machine
 - SCI caches resolved JVM instance methods, static methods, constructors and fields per call site for performance
 - Add experimental [`babashka.ffi`](doc/ffi.md) for calling functions in native shared libraries
 - On Linux, the install script now installs the dynamic binary by default. It installs the static binary on musl systems and on systems with glibc older than 2.17. The `--static` and `--dynamic` options override the automatic selection

--- a/script/fetch_tarball.sh
+++ b/script/fetch_tarball.sh
@@ -1,0 +1,58 @@
+# Fetches a pinned source tarball, for the scripts that build a dependency
+# from source. Sourced, not run.
+#
+# Three things keep a build from failing on someone else's outage. A cache,
+# so a tarball is fetched once per machine. Retries, for the short timeout
+# that took a release build down on 2026-08-25. And mirrors, tried in turn.
+#
+# Mirrors are safe here because every tarball is pinned by sha256: bytes
+# that do not match are rejected, and the next mirror gets a turn. So a
+# stale mirror costs a download, not a wrong build.
+
+# the sha256sum on macOS is a different tool that takes no checksum file
+if sha256sum --version > /dev/null 2>&1; then
+    tarball_sha256() { sha256sum "$1" | cut -d' ' -f1; }
+else
+    tarball_sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+fi
+
+# fetch_tarball <file> <sha256> <url>...
+#
+# Leaves the verified tarball at <file> in the working directory. Fails when
+# no url serves the pinned bytes.
+fetch_tarball() {
+    local file=$1 sha=$2
+    shift 2
+    local cache_dir="${BABASHKA_TARBALL_CACHE:-$HOME/.cache/babashka-tarballs}"
+    local cached="$cache_dir/$sha-$file"
+
+    if [ -f "$cached" ] && [ "$(tarball_sha256 "$cached")" = "$sha" ]; then
+        echo "fetch_tarball: $file from the cache" >&2
+        cp "$cached" "$file"
+        return 0
+    fi
+
+    local url actual
+    for url in "$@"; do
+        echo "fetch_tarball: $file from $url" >&2
+        # --retry covers the transient errors, a timeout among them
+        if ! curl -sL --fail --show-error --connect-timeout 20 \
+             --retry 4 --retry-delay 2 --retry-connrefused \
+             -o "$file" "$url"; then
+            echo "fetch_tarball: $url did not answer" >&2
+            continue
+        fi
+        actual="$(tarball_sha256 "$file")"
+        if [ "$actual" != "$sha" ]; then
+            echo "fetch_tarball: $url served $actual, expected $sha" >&2
+            rm -f "$file"
+            continue
+        fi
+        mkdir -p "$cache_dir"
+        cp "$file" "$cached"
+        return 0
+    done
+
+    echo "fetch_tarball: no source served $file with sha256 $sha" >&2
+    return 1
+}

--- a/script/setup-musl
+++ b/script/setup-musl
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# shellcheck source=script/fetch_tarball.sh
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/fetch_tarball.sh"
+
 if  [[ -z "${BABASHKA_STATIC:-}" ]]; then
     echo "BABASHKA_STATIC wasn't set, skipping musl installation."
     exit 0
@@ -25,8 +28,12 @@ fi
 MUSL_VERSION="1.2.6"
 MUSL_SHA256="d585fd3b613c66151fc3249e8ed44f77020cb5e6c1e635a616d3f9f82460512a"
 
-curl -O -sL --fail --show-error "https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz"
-echo "${MUSL_SHA256} musl-${MUSL_VERSION}.tar.gz" | sha256sum --check
+fetch_tarball "musl-${MUSL_VERSION}.tar.gz" "$MUSL_SHA256" \
+    "https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz" \
+    "https://sources.buildroot.net/musl/musl-${MUSL_VERSION}.tar.gz" \
+    "https://sources.openwrt.org/musl-${MUSL_VERSION}.tar.gz" \
+    "http://deb.debian.org/debian/pool/main/m/musl/musl_${MUSL_VERSION}.orig.tar.gz"
+
 tar xf "musl-${MUSL_VERSION}.tar.gz"
 
 cd "musl-${MUSL_VERSION}"
@@ -47,10 +54,10 @@ ln -sf /usr/local/musl/bin/musl-gcc /usr/bin/musl-gcc
 ZLIB_VERSION="1.2.13"
 ZLIB_SHA256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 
-# stable archive path
-curl -O -sL --fail --show-error "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
+fetch_tarball "zlib-${ZLIB_VERSION}.tar.gz" "$ZLIB_SHA256" \
+    "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" \
+    "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz"
 
-echo "${ZLIB_SHA256} zlib-${ZLIB_VERSION}.tar.gz" | sha256sum --check
 tar xf "zlib-${ZLIB_VERSION}.tar.gz"
 
 arch=${BABASHKA_ARCH:-"x86_64"}

--- a/script/setup-zlib
+++ b/script/setup-zlib
@@ -7,13 +7,16 @@
 
 set -euo pipefail
 
+# shellcheck source=script/fetch_tarball.sh
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/fetch_tarball.sh"
+
 ZLIB_VERSION="1.2.13"
 ZLIB_SHA256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 
-# stable archive path
-curl -O -sL --fail --show-error "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
+fetch_tarball "zlib-${ZLIB_VERSION}.tar.gz" "$ZLIB_SHA256" \
+    "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" \
+    "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz"
 
-echo "${ZLIB_SHA256} zlib-${ZLIB_VERSION}.tar.gz" | sha256sum --check
 tar xf "zlib-${ZLIB_VERSION}.tar.gz"
 
 cd "zlib-${ZLIB_VERSION}"


### PR DESCRIPTION
musl.libc.org timed out during a run and took the static Linux release build with it. The musl and zlib tarballs came from a single host each, with no retry, no mirror and no cache.

script/fetch_tarball.sh now does all three. Mirrors are safe because every tarball is pinned by sha256: bytes that do not match are rejected and the next mirror gets its turn, so a stale mirror costs a download rather than a wrong build. Each mirror below was checked to serve the pinned bytes. The cache travels with the CircleCI caches, so an outage only hurts on a miss.


