### PR TITLE
Support UNIX domain sockets in the socket REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- `bb socket-repl` can listen on a UNIX domain socket: `bb socket-repl unix://<path>`
 - `babashka.ffi`: a C function that takes a struct as an argument, or returns one, without a pointer in between. Define the fields with a layout, such as `[:struct [[:x :int] [:y :int]]]`. Use a map for the field values. `sizeof` and `alignof` now accept layouts. Struct calls use libffi
 - Link a static libffi for FFI calls that the fixed native call shapes cannot make. Set `BABASHKA_LIBFFI` to another archive or `none`
 - Linux: dynamic binaries now require glibc 2.28. The install script selects the static binary on older systems. See ADR 0010

--- a/src/babashka/impl/clojure/core/server.clj
+++ b/src/babashka/impl/clojure/core/server.clj
@@ -22,7 +22,10 @@
   (:import
    [clojure.lang LineNumberingPushbackReader]
    [java.io BufferedWriter InputStreamReader OutputStreamWriter]
-   [java.net InetAddress Socket ServerSocket SocketException]
+   [java.net BindException InetAddress Socket ServerSocket SocketException
+    StandardProtocolFamily UnixDomainSocketAddress]
+   [java.nio.channels Channels ClosedChannelException ServerSocketChannel SocketChannel]
+   [java.nio.file Files LinkOption Path Paths]
    [java.util.concurrent.locks ReentrantLock]))
 
 (set! *warn-on-reflection* true)
@@ -57,6 +60,77 @@
           (throw (Exception. (str "can't resolve: " valf)))))
     valf))
 
+(defprotocol Listener
+  (accept-conn [listener] "Blocks until a client connects; returns the connection.")
+  (listener-closed? [listener])
+  (close-listener! [listener])
+  (describe [listener] "Human-readable address, for the startup banner."))
+
+(defprotocol Connection
+  (conn-in [conn])
+  (conn-out [conn])
+  (close-conn! [conn]))
+
+(extend-protocol Connection
+  Socket
+  (conn-in [conn] (.getInputStream conn))
+  (conn-out [conn] (.getOutputStream conn))
+  (close-conn! [conn] (.close conn))
+  SocketChannel
+  (conn-in [conn] (Channels/newInputStream conn))
+  (conn-out [conn] (Channels/newOutputStream conn))
+  (close-conn! [conn] (.close conn)))
+
+(extend-protocol Listener
+  ServerSocket
+  (accept-conn [listener] (.accept listener))
+  (listener-closed? [listener] (.isClosed listener))
+  (close-listener! [listener] (.close listener))
+  (describe [listener]
+    (str (.getHostAddress (.getInetAddress listener)) ":" (.getLocalPort listener))))
+
+(defrecord UnixListener [^ServerSocketChannel channel ^Path path]
+  Listener
+  (accept-conn [_] (.accept channel))
+  (listener-closed? [_] (not (.isOpen channel)))
+  (close-listener! [_]
+    (.close channel)
+    (Files/deleteIfExists path))
+  (describe [_] (str path)))
+
+(defn- bind-unix-listener ^ServerSocketChannel [^Path path]
+  (let [address (UnixDomainSocketAddress/of path)
+        channel (ServerSocketChannel/open StandardProtocolFamily/UNIX)]
+    (try (.bind channel address)
+         (catch BindException e
+           ;; A file already exists at path. If nothing accepts connections on
+           ;; it, it was left behind by a dead process: remove it and rebind.
+           (let [stale? (try (.close (SocketChannel/open address)) false
+                             (catch java.io.IOException _ true))]
+             (if stale?
+               (do (Files/deleteIfExists path)
+                   (.bind channel address))
+               (do (.close channel)
+                   (throw (ex-info (str "A server is already listening on " path)
+                                   {:socket (str path)} e))))))
+         (catch SocketException e
+           ;; e.g. ENOENT: the parent directory of path does not exist
+           (.close channel)
+           (let [parent (.getParent path)
+                 msg (if (and parent (not (Files/exists parent (into-array LinkOption []))))
+                       (str "Cannot start server at " path
+                            ": parent directory " parent " does not exist")
+                       (str "Cannot start server at " path ": " (.getMessage e)))]
+             (throw (ex-info msg {:socket (str path)} e)))))
+    channel))
+
+(defn- unix-listener [{:keys [socket]}]
+  (let [path (.toAbsolutePath (Paths/get ^String socket (into-array String [])))
+        channel (bind-unix-listener path)]
+    ;; SIGINT/exit is the normal way these servers stop; clean up the file.
+    (.deleteOnExit (.toFile path))
+    (->UnixListener channel path)))
+
 (defn- accept-connection
   "Start accept function, to be invoked on a client thread, given:
     conn - client socket
@@ -67,7 +141,7 @@
     err - err stream
     accept - accept fn symbol to invoke
     args - to pass to accept-fn"
-  [ctx ^Socket conn client-id in out err accept args]
+  [ctx conn client-id in out err accept args]
   (let [accept (resolve-fn ctx accept)]
     (try
       (binding [*session* {:server name :client client-id}]
@@ -79,45 +153,51 @@
             (alter-var-root #'servers assoc-in [name :sessions client-id] {}))
           (apply accept args)))
       (catch SocketException _disconnect)
+      (catch ClosedChannelException _disconnect)
       (finally
         (with-lock lock
           (alter-var-root #'servers update-in [name :sessions] dissoc client-id))
-        (.close conn)))))
+        (close-conn! conn)))))
 
 (defn start-server
   "Start a socket server given the specified opts:
     :address Host or address, string, defaults to loopback address
-    :port Port, integer, required
+    :port Port, integer, required unless :socket is given
+    :socket Path to a UNIX domain socket file, mutually exclusive with :address and :port
     :name Name, required
     :accept Namespaced symbol of the accept function to invoke, required
     :args Vector of args to pass to accept function
     :bind-err Bind *err* to socket out stream?, defaults to true
     :server-daemon Is server thread a daemon?, defaults to true
     :client-daemon Are client threads daemons?, defaults to true
-   Returns server socket."
-  ^ServerSocket [ctx opts]
-  (let [{:keys [address port name accept args bind-err server-daemon client-daemon]
+   Returns the server listener: a ServerSocket, or a UNIX domain socket
+   listener when :socket was given."
+  [ctx opts]
+  (let [{:keys [address port socket name accept args bind-err server-daemon client-daemon]
          :or {bind-err true
               server-daemon true
               client-daemon true}} opts
-        address (InetAddress/getByName address)  ;; nil returns loopback
-        socket (ServerSocket. port 0 address)]
+        socket (if socket
+                 (unix-listener opts)
+                 ;; nil address returns loopback
+                 (ServerSocket. port 0 (InetAddress/getByName address)))]
     (with-lock lock
       (alter-var-root #'servers assoc name {:name name, :socket socket, :sessions {}}))
     (thread
       (str "Clojure Server " name) server-daemon
       (try
         (loop [client-counter 1]
-          (when (not (.isClosed socket))
+          (when (not (listener-closed? socket))
             (try
-              (let [conn (.accept socket)
-                    in (LineNumberingPushbackReader. (InputStreamReader. (.getInputStream conn)))
-                    out (BufferedWriter. (OutputStreamWriter. (.getOutputStream conn)))
+              (let [conn (accept-conn socket)
+                    in (LineNumberingPushbackReader. (InputStreamReader. (conn-in conn)))
+                    out (BufferedWriter. (OutputStreamWriter. (conn-out conn)))
                     client-id (str client-counter)]
                 (thread
                   (str "Clojure Connection " name " " client-id) client-daemon
                   (accept-connection ctx conn client-id in out (if bind-err out *err*) accept args)))
-              (catch SocketException _disconnect))
+              (catch SocketException _disconnect)
+              (catch ClosedChannelException _disconnect))
             (recur (inc client-counter))))
         (finally
           (with-lock lock
@@ -132,10 +212,10 @@
    (stop-server (:server *session*)))
   ([name]
    (with-lock lock
-     (let [server-socket ^ServerSocket (get-in servers [name :socket])]
-       (when server-socket
+     (let [listener (get-in servers [name :socket])]
+       (when listener
          (alter-var-root #'servers dissoc name)
-         (.close server-socket)
+         (close-listener! listener)
          true)))))
 
 (defn stop-servers

--- a/src/babashka/impl/socket_repl.clj
+++ b/src/babashka/impl/socket_repl.clj
@@ -14,28 +14,33 @@
             (repl/repl (common/ctx))))
 
 (defn parse-opts [opts]
-  (let [opts (str/trim opts)
-        opts (if (str/starts-with? opts "{")
-               (edn/read-string opts)
-               (let [parts (str/split opts #":")
-                     [host port] (if (= 1 (count parts))
-                                   [nil (Integer. ^String (first parts))]
-                                   [(first parts) (Integer. ^String (second parts))])]
-                 {:address host
-                  :port port
-                  :name "bb"
-                  :accept 'clojure.core.server/repl
-                  :args []}))]
-    opts))
+  (let [opts (str/trim opts)]
+    (cond
+      (str/starts-with? opts "{")
+      (edn/read-string opts)
+
+      (str/starts-with? opts "unix://")
+      {:socket (subs opts (count "unix://"))
+       :name "bb"
+       :accept 'clojure.core.server/repl
+       :args []}
+
+      :else
+      (let [parts (str/split opts #":")
+            [host port] (if (= 1 (count parts))
+                          [nil (Integer. ^String (first parts))]
+                          [(first parts) (Integer. ^String (second parts))])]
+        {:address host
+         :port port
+         :name "bb"
+         :accept 'clojure.core.server/repl
+         :args []}))))
 
 (defn start-repl! [opts sci-ctx]
   (let [opts (parse-opts opts)
-        socket (server/start-server sci-ctx opts)
-        inet-address (java.net.InetAddress/getByName (:address opts))]
+        socket (server/start-server sci-ctx opts)]
     (binding [*out* *err*]
-      (println (format "Babashka socket REPL started at %s:%d"
-                       (.getHostAddress inet-address)
-                       (.getLocalPort socket))))
+      (println (str "Babashka socket REPL started at " (server/describe socket))))
     socket))
 
 (defn stop-repl! []

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -217,6 +217,7 @@ REPL:
 
   repl                 Start REPL.
   socket-repl  [addr]  Start a socket REPL. Address defaults to localhost:1666.
+                       Addr may also be a UNIX domain socket: unix://<path>.
   nrepl-server [addr]  Start nREPL server. Address defaults to localhost:1667.
 
 Tasks:
@@ -368,8 +369,20 @@ Use bb run --help to show this help output.
                         sci/file (.getAbsolutePath f)}
       (sci/eval-string* (common/ctx) s))))
 
+(defn- exit-on-server-error
+  "Runs f. When it throws an ex-info about a server socket, prints the
+  message without a stack trace and exits."
+  [f]
+  (try (f)
+       (catch clojure.lang.ExceptionInfo e
+         (if (:socket (ex-data e))
+           (do (binding [*out* *err*]
+                 (println (ex-message e)))
+               (System/exit 1))
+           (throw e)))))
+
 (defn start-socket-repl! [address ctx]
-  (socket-repl/start-repl! address ctx))
+  (exit-on-server-error #(socket-repl/start-repl! address ctx)))
 
 (defn start-nrepl! [address]
   (let [opts (nrepl-server/parse-opt address)]


### PR DESCRIPTION
## Summary

`bb socket-repl unix://<path>` listens on a UNIX domain socket instead of a TCP port:

```
$ bb socket-repl unix:///tmp/bb.sock
Babashka socket REPL started at /tmp/bb.sock
$ nc -U /tmp/bb.sock
Babashka v1.13.220-SNAPSHOT
user=> (+ 1 2)
3
```

TCP behavior (`bb socket-repl [addr:]port`) is unchanged; the address kind is picked by the `unix://` prefix.

## Use case

A multi-user server running many REPLs (one or more per user). With TCP, every REPL is a localhost port that any user on the machine can connect to — the REPLs can leak between users. With Unix domain sockets, each socket is a file whose permissions restrict access to its owner, so each user's REPLs stay private to them.

## Details

- A stale socket file left behind by a dead process is detected (connect probe fails with `ECONNREFUSED`) and removed before rebinding, so restarts just work.
- Bind failures print a clean one-line error instead of a stack trace:
  - occupied socket: `Cannot start server at /tmp/bb.sock: socket is already in use by another process`
  - missing parent directory: `Cannot start server at /a/b/c.sock: parent directory /a/b does not exist`
- The socket file is removed on server stop and on JVM exit (shutdown hook).
- Implemented in `babashka.impl.clojure.core.server` on `java.net.UnixDomainSocketAddress` / `ServerSocketChannel` (JDK 16+), adapting the accepted channels to the existing socket-REPL accept loop; no new dependencies.

## Testing

- JVM (`clojure -M:main`) and native image: happy path over `nc -U`, stale-socket rebind, occupied-socket error, missing-parent-dir error, TCP regression (`bb socket-repl 1666`).
- CHANGELOG entry added under Unreleased.

## Question on nREPL

I also implemented the same `unix://<path>` support for `--nrepl-server`, but left it out of this PR until the idea of Unix-socket REPL connections is accepted in principle. If this direction is acceptable, I'm happy to follow up with the nREPL counterpart.