### PR TITLE
Resolve deps in-process by default

### DIFF
--- a/.circleci/script/gen_ci.clj
+++ b/.circleci/script/gen_ci.clj
@@ -85,7 +85,6 @@ tar xzf /tmp/release/babashka-$VERSION-linux-amd64.tar.gz -C .")
     :docker            [{:image "circleci/clojure:openjdk-11-lein-2.9.8-bullseye"}]
     :working_directory "~/repo"
     :environment       {:LEIN_ROOT         "true"
-                        :BABASHKA_DEPS_RESOLVER "bb"
                         :BABASHKA_PLATFORM "linux"
                         :GRAALVM_VERSION   graalvm-version
                         :GRAALVM_HOME      graalvm-home
@@ -127,9 +126,6 @@ java -jar \"$jar\" --config .build/bb.edn --deps-root . release-artifact \"$refl
 (defn unix
   [shorted? static? musl? arch executor-conf resource-class graalvm-home platform graalvm-version]
   (let [env              {:LEIN_ROOT         "true"
-                          ;; the suite resolves deps in-process; the java
-                          ;; path has its own tests that ask for it by name
-                          :BABASHKA_DEPS_RESOLVER "bb"
                           :GRAALVM_VERSION   graalvm-version
                           :GRAALVM_HOME      graalvm-home
                           :BABASHKA_PLATFORM (if (= "mac" platform)

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       LEIN_ROOT: "true"
-      BABASHKA_DEPS_RESOLVER: bb
       GRAALVM_VERSION: "25.0.4"
       BABASHKA_PLATFORM: ${{ matrix.name }} # used in release script
       BABASHKA_TEST_ENV: native

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LEIN_ROOT: "true"
-      BABASHKA_DEPS_RESOLVER: bb
       BABASHKA_PLATFORM: linux # could be used in jar name
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BABASHKA_SHA: ${{ github.sha }}
@@ -112,7 +111,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       LEIN_ROOT: "true"
-      BABASHKA_DEPS_RESOLVER: bb
       GRAALVM_VERSION: ${{ matrix.graalvm_version }}
       BABASHKA_PLATFORM: ${{ matrix.name }} # used in release script
       BABASHKA_ARCH: ${{ matrix.arch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ A preview of the next release can be installed from
 - The bundled `clojure.spec.alpha`, tools.deps and gitlibs win over jars of them on the classpath, which cannot load in bb. tools.build's test suite runs as a lib test.
 - tools.build `install` runs in bb: the jar and POM land in the local repository with the files Maven Resolver writes, and bb serves that task before a tools.build jar on the classpath.
 - tools.build runs from source, `install` excepted: the bundled tools.deps wins over a tools.deps jar on the classpath, `clojure.java.process/io-task` is exposed, and `(.-name ns)` works on a namespace.
-- Resolve deps without a JVM: set `:deps-resolver :bb` in `bb.edn` or the `add-deps` map, or `BABASHKA_DEPS_RESOLVER=bb`. Default stays `jvm` for now.
+- Resolve deps without a JVM, now the default. `:deps-resolver :jvm` in `bb.edn` or the `add-deps` map, or `BABASHKA_DEPS_RESOLVER=jvm`, resolves with Java as before.
 - [#2040](https://github.com/babashka/babashka/issues/2040): allow `.get`/`.put` on typed NIO buffers (`IntBuffer`, `FloatBuffer`, `LongBuffer`, `DoubleBuffer`, `ShortBuffer`) and primitive arrays `[F]`, `[J]`, `[D]`, `[S]` so SCI can call bulk `Buffer.get(primitive[])` / `.put`
 - Fix interop for `(Boolean. false)` which picked the wrong overload
 - Bump Clojure to `1.12.6`

--- a/doc/adr/ai/0002-dependency-resolution-without-a-jvm.md
+++ b/doc/adr/ai/0002-dependency-resolution-without-a-jvm.md
@@ -27,8 +27,8 @@ Layers, top to bottom, with what is ours and what is not:
    spawned-java behaviour is the default of that var, so existing users of
    deps.clj as a library, Cursive among them, see no change.
 2. `babashka.deps` and `babashka.impl.deps` bind `*make-classpath-fn*` to an
-   in-process run when the resolver is `bb`, and leave it alone when it is
-   `jvm` or unset. `:deps-resolver` in the deps map says it, then the one
+   in-process run when the resolver is `bb` or unset, and leave it alone
+   when it is `jvm`; bb became the default on 2026-09-10. `:deps-resolver` in the deps map says it, then the one
    in bb.edn, which a task's `:extra-deps` inherit; without either
    `BABASHKA_DEPS_RESOLVER` decides, read through the resolve's
    environment view, so `:env` and `:extra-env` on `add-deps` and

--- a/src/babashka/deps.clj
+++ b/src/babashka/deps.clj
@@ -7,21 +7,24 @@
             [sci.core :as sci]))
 
 (defn ^:no-doc make-classpath-fn
-  "Returns an in-process classpath resolver for :bb, or nil for the JVM.
-  resolver takes precedence over BABASHKA_DEPS_RESOLVER from getenv.
-  Defaults to the JVM. dir is the project directory.
-  getenv maps environment names to values."
+  "Returns an in-process classpath resolver for :bb, the default, or nil
+  for :jvm. resolver takes precedence over BABASHKA_DEPS_RESOLVER from
+  getenv. dir is the project directory. getenv maps environment names to
+  values."
   [dir getenv resolver]
-  (when (= "bb" (some-> (or resolver (getenv "BABASHKA_DEPS_RESOLVER")) name))
-    (fn [{:keys [args out]}]
-      ;; deps.clj has bound *getenv-fn* by now, so this is the config dir
-      ;; of the call's own environment, -Srepro or not
-      (let [opts {:config-dir (deps/get-config-dir)
-                  :getenv deps/*getenv-fn*}]
-        (if (= :string out)
-          {:out (with-out-str (tools-deps/make-classpath! dir args opts))}
-          (do (tools-deps/make-classpath! dir args opts)
-              {:out nil}))))))
+  (let [r (some-> (or resolver (not-empty (getenv "BABASHKA_DEPS_RESOLVER"))) name)]
+    (when-not (contains? #{nil "bb" "jvm"} r)
+      (throw (ex-info (str "Unknown deps resolver " r ", use bb or jvm") {:resolver r})))
+    (when-not (= "jvm" r)
+      (fn [{:keys [args out]}]
+        ;; deps.clj has bound *getenv-fn* by now, so this is the config dir
+        ;; of the call's own environment, -Srepro or not
+        (let [opts {:config-dir (deps/get-config-dir)
+                    :getenv deps/*getenv-fn*}]
+          (if (= :string out)
+            {:out (with-out-str (tools-deps/make-classpath! dir args opts))}
+            (do (tools-deps/make-classpath! dir args opts)
+                {:out nil})))))))
 
 (defn ^:no-doc getenv-fn
   "Returns an environment lookup function for deps.clj.

--- a/src/babashka/impl/deps.clj
+++ b/src/babashka/impl/deps.clj
@@ -62,7 +62,7 @@
 
   Set :deps-resolver in the deps map to :bb for in-process resolution or
   :jvm to use Java. Defaults to :deps-resolver in bb.edn, then
-  BABASHKA_DEPS_RESOLVER, then jvm."
+  BABASHKA_DEPS_RESOLVER, then bb."
   ([deps-map] (add-deps deps-map nil))
   ([deps-map {:keys [:aliases :env :extra-env :force]}]
    (let [deps-root (:deps-root @bb-edn)

--- a/test/babashka/deps_test.clj
+++ b/test/babashka/deps_test.clj
@@ -15,9 +15,9 @@
      edn-str)))
 
 (deftest resolver-switch-test
-  ;; BABASHKA_DEPS_RESOLVER picks the resolver; unset means the java that
-  ;; deps.clj spawns, bb means tools.deps in this process. Both resolve
-  ;; the same dependency.
+  ;; BABASHKA_DEPS_RESOLVER picks the resolver: jvm is the java deps.clj
+  ;; spawns, bb or unset is tools.deps in this process. Both resolve the
+  ;; same dependency.
   (doseq [resolver ["jvm" "bb"]]
     (testing resolver
       (is (= 3 (bb (format "
@@ -26,6 +26,19 @@
 (require '[medley.core :as m])
 (m/find-first odd? [2 3 4])
 " resolver))))))
+  (testing "unset means bb: :env replaces the environment, so there is no resolver setting and no java"
+    (is (= 3 (bb "
+(babashka.deps/add-deps '{:deps {medley/medley {:mvn/version \"1.3.0\"}}}
+                        {:force true :env {\"PATH\" \"/nonexistent\" \"JAVA_CMD\" \"\"}})
+(require '[medley.core :as m])
+(m/find-first odd? [2 3 4])
+"))))
+  (testing "an unknown resolver is an error"
+    (is (thrown-with-msg? Exception #"Unknown deps resolver nope, use bb or jvm"
+                          (bb "
+(babashka.deps/add-deps '{:deps {medley/medley {:mvn/version \"1.3.0\"}}}
+                        {:force true :extra-env {\"BABASHKA_DEPS_RESOLVER\" \"nope\"}})
+"))))
   (testing ":deps-resolver in the deps map, no environment needed"
     (is (= 3 (bb "
 (babashka.deps/add-deps '{:deps {medley/medley {:mvn/version \"1.3.0\"}} :deps-resolver :bb}
@@ -57,11 +70,11 @@
     [(str config) (str (fs/canonicalize (fs/file tool-root "src")))]))
 
 (deftest resolver-from-process-env-test
-  ;; the CI leg that sets BABASHKA_DEPS_RESOLVER=bb must actually resolve
-  ;; in-process: with no java to be found, only that resolver can succeed.
+  ;; unless the process asks for jvm, resolution must run in-process: with
+  ;; no java to be found, only the bb resolver can succeed.
   ;; JAVA_CMD "" keeps deps.clj from looking for java and gives it nothing
   ;; runnable.
-  (when (= "bb" (System/getenv "BABASHKA_DEPS_RESOLVER"))
+  (when-not (= "jvm" (System/getenv "BABASHKA_DEPS_RESOLVER"))
     (is (= 3 (bb "
 (babashka.deps/add-deps '{:deps {medley/medley {:mvn/version \"1.3.0\"}}}
                         {:force true :extra-env {\"PATH\" \"/nonexistent\" \"JAVA_HOME\" \"\" \"JAVA_CMD\" \"\"}})


### PR DESCRIPTION
bb's own resolver is now what runs when neither :deps-resolver nor BABASHKA_DEPS_RESOLVER says otherwise; jvm is the way back to the java deps.clj spawns, and an unknown value is an error instead of a silent fallback. CI stops setting BABASHKA_DEPS_RESOLVER so every job tests the default; the jvm path keeps its own tests that ask for it by name.
